### PR TITLE
Expand esbuild migration risk analysis

### DIFF
--- a/docs/adr-002-replace-webpack-babel-with-esbuild.md
+++ b/docs/adr-002-replace-webpack-babel-with-esbuild.md
@@ -131,6 +131,9 @@ implementation choices can evolve independently.
 | Production minification/no comments | `TerserPlugin` + post-bundle Babel CLI minify in `package.json` | esbuild `minify` and `legalComments` options[^esbuild-api] | No plugin expected |
 | Webpack-specific runtime escape hatch | `__non_webpack_require__` in `lib/v8-snapshot-util.ts` | esbuild does not provide this identifier | **Required**: rewrite shim for bundler-agnostic runtime require |
 
+Table 2: Loader/transform inventory - current Webpack/Babel behaviours,
+esbuild-native replacements, and required plugin or bespoke work.
+
 ### Required plugin and bespoke-transform analysis
 
 The subsection below is the proposed implementation approach for addressing the
@@ -244,6 +247,8 @@ requirements are implemented and passing in CI.
 | Snapshot bootstrap shim | No migration-era test for replacing `__non_webpack_require__` semantics | Add production-mode integration test that boots renderer snapshot path and confirms module loading succeeds |
 | CLI shebang behaviour | No assertion that bundled CLI output preserves executable shebang behaviour after removing `shebang-loader` | Add CLI artefact test that checks shebang presence/position and executes a basic command path |
 | Minification/source map expectations | No explicit contract test for production minification and development source map quality after switching off Terser/Babel post-pass | Add build mode tests that assert minified production output properties and development source map availability |
+
+Table 3: Validation gaps and required tests for the esbuild migration.
 
 Required CI acceptance criteria for migration PRs:
 


### PR DESCRIPTION
Detail the ADR risk section with a repository-specific transform inventory that maps each current Webpack/Babel behaviour to esbuild-native capability, plugin need, or bespoke work.

Document the highest-risk migration surfaces:
- styled-jsx transform handling
- static copy and copy-only build behaviour
- __non_webpack_require__ runtime shim replacement
- externals and ignore semantics
- build API adoption for plugin workflows

Add source references for esbuild APIs/plugins, styled-jsx, and candidate plugin packages so follow-on implementation work can validate assumptions quickly.

## Summary by Sourcery

Expand the esbuild migration ADR with a repository-specific risk analysis and required validation criteria for replacing Webpack/Babel.

Documentation:
- Add a loader/transform inventory mapping current Webpack/Babel behaviour to esbuild capabilities or required plugins/bespoke work.
- Document high-risk migration areas including styled-jsx handling, static copy and copy-only bundles, runtime shims, externals/ignore semantics, and build API adoption.
- Define validation gaps and concrete test coverage requirements to confirm build-pipeline equivalence after migration.
- Add source references for esbuild APIs, styled-jsx, and candidate esbuild/Babel bridge and copy plugins.

Tests:
- Specify CI acceptance criteria and new build equivalence, smoke, and artefact contract tests needed to safely complete the Webpack/Babel-to-esbuild migration.