### PR TITLE
9.2.4 `styled-jsx` regression coverage

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1018,6 +1018,33 @@ elements. Apply both the CSS Module token and the legacy string:
 Document intentionally retired legacy class names in the migration ExecPlan
 under `Decision log`.
 
+### Styled-jsx removal regression checklist
+
+After touching renderer styles that previously relied on `styled-jsx`, replay
+the regression contract introduced by roadmap item `9.2.4`:
+
+1. Run the focused unit/build coverage:
+   `test/unit/esbuild-migration-contracts.test.ts`,
+   `test/unit/search-box-css-modules.test.tsx`,
+   `test/unit/new-tab.test.tsx`, and
+   `test/unit/term-report-renderer.test.ts`.
+2. Keep the packaged-output residue scan green. The fast lane now checks
+   `dist/app/renderer/bundle.js` and `dist/app/renderer/bundle.css` for
+   forbidden `styled-jsx/style`, `styled-jsx`, and raw `<style jsx` residue
+   before Electron startup assertions continue.
+3. Keep parity coverage anchored to the representative migration surfaces:
+   `SearchBox` for `--search-*` custom properties, `DropdownButton` in
+   `new-tab.tsx` for `--new-tab-*` styling and local CSS Module rules,
+   `term.tsx` for DOM-attached `term_fit` / `term_wrapper` compatibility
+   classes, and `tabs.module.css` for the preserved `:global(.tabs_list)`
+   selector contract.
+4. Run both E2E lanes after build output changes. `bun run test:e2e:fast`
+   guards packaged renderer cleanliness and startup, while
+   `bun run test:e2e:deep` validates the terminal interaction path plus live
+   style parity for themed new-tab UI and legacy terminal classes.
+5. On WSL2, follow `docs/testing-wsl2.md` and run the E2E commands under
+   `xvfb-run --auto-servernum` unless a working X server is already available.
+
 ### Label-threading with translation wrappers
 
 Accessibility labels that vary by locale are threaded via a narrow prop

--- a/docs/execplans/9-2-4-integration-and-regression-coverage-for-styled-jsx-removal.md
+++ b/docs/execplans/9-2-4-integration-and-regression-coverage-for-styled-jsx-removal.md
@@ -1,0 +1,419 @@
+# Add integration and regression coverage for styled-jsx removal
+
+This ExecPlan (execution plan) is a living document. The sections
+`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises &
+Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be
+kept up to date as work proceeds.
+
+Status: DRAFT
+
+## Purpose / big picture
+
+Roadmap item `9.2.4` closes the remaining verification gap in the
+renderer styling migration. The repository has already migrated renderer
+components from `styled-jsx` to CSS Modules (`1.4.17`), removed the
+bridge-only tooling (`1.4.18`), and established layered end-to-end
+(E2E) coverage (`9.2.3`). What is still missing is a single,
+repository-level proof that packaged builds and real renderer startup
+paths contain no unresolved `styled-jsx` runtime residue, and that the
+replacement CSS Modules behaviour still covers the three migration
+patterns documented in the earlier plans:
+
+1. local scoped styles,
+2. legacy global selector compatibility, and
+3. dynamic theme values via CSS custom properties.
+
+Success is observable when:
+
+1. The unit/build contract suite proves both fixture bundles and
+   packaged outputs contain no `styled-jsx`, `styled-jsx/style`, or raw
+   `<style jsx>` residue.
+2. The fast E2E lane proves packaged startup is clean and fails early if
+   forbidden `styled-jsx` runtime imports appear in built artefacts.
+3. The deep E2E lane exercises representative renderer surfaces and
+   proves CSS Modules parity for local styles, preserved global
+   selectors, and dynamic theme variables without introducing flaky,
+   screenshot-heavy assertions.
+4. `docs/developers-guide.md` documents the final regression contract so
+   future renderer styling work replays the correct checks.
+5. `docs/roadmap.md` marks item `9.2.4` done only after the full
+   validation sequence passes.
+
+This document is planning-only. Implementation must not begin until the
+user explicitly approves this ExecPlan.
+
+## Documentation and skills
+
+Read these documents before editing code:
+
+- `docs/roadmap.md` for the governing definition of `9.2.4`, `1.4.17`,
+  and `9.2.3`.
+- `docs/velocetty-design.md` section `Renderer styling migration model`
+  for the target renderer styling contract.
+- `docs/execplans/1-4-16-styled-jsx-to-css-modules-migration-approach-and-inventory.md`
+  for the migration patterns and parity expectations.
+- `docs/execplans/1-4-17-migrate-renderer-style-blocks-from-styled-jsx-to-css-modules.md`
+  for concrete CSS Modules migration rules and parity examples.
+- `docs/execplans/1-4-18-remove-styled-jsx-bridge-tooling-and-bridge-only-babel-dependencies.md`
+  for the bridge-removal follow-up context that points directly at this
+  roadmap item.
+- `docs/execplans/enhance-e2e-testing-strategy.md` for fast-lane and
+  deep-lane intent, command names, and CI policy.
+- `docs/developers-guide.md` for the current CSS Modules conventions and
+  E2E lane descriptions.
+
+Use these skills during implementation:
+
+- `execplans` to keep this file current as work proceeds.
+- `grepai` for intent-based repository search.
+- `leta` for symbol-aware code navigation in the touched test/build
+  modules.
+
+## Repository orientation
+
+The current branch already contains several pieces of the final
+regression story, but they are not yet tied together in the way
+`9.2.4` requires.
+
+`test/unit/esbuild-migration-contracts.test.ts` already checks that
+`createRendererBuildOptions(...)` uses `'.module.css': 'local-css'` and
+that a synthetic renderer bundle no longer emits `styled-jsx` runtime
+markers. That suite is the right home for stronger build-contract
+assertions because it already exercises esbuild directly.
+
+`test/e2e/electron.e2e.test.ts` already validates packaged startup,
+renderer-readiness markers, critical renderer console errors, and
+unresolved `@shared` runtime imports in selected packaged files. It does
+not yet inspect packaged artefacts for `styled-jsx` residue.
+
+`test/e2e-deep/terminal-input-path.e2e.ts` already provides a real
+packaged-app deep-lane interaction test, but it only proves terminal
+input/output flow. It does not yet validate styling migration parity.
+
+Representative renderer styling surfaces already exist and should be
+reused instead of inventing new migration examples:
+
+- Dynamic theme values:
+  `lib/components/searchBox.tsx` plus
+  `test/unit/search-box-css-modules.test.tsx`,
+  and `lib/components/new-tab.tsx` plus
+  `test/unit/new-tab.test.tsx`.
+- Legacy global selector compatibility:
+  `lib/components/tabs.module.css` preserves `.tabs_list`,
+  and `lib/components/term.tsx` /
+  `lib/components/term.module.css` preserve `term_fit` and
+  `term_wrapper`.
+- Global CSS behaviour with custom properties:
+  `lib/components/terms.module.css` uses `:global(::-webkit-scrollbar*)`
+  with `--scrollbar-thumb`.
+
+The implementation should extend these existing surfaces first. Only add
+new test files when the existing suites cannot express the required
+behaviour cleanly.
+
+## Constraints
+
+- This plan remains in draft status until user approval. Do not
+  implement any milestone before approval is explicit.
+- Do not add new external dependencies. Use the existing Bun, Playwright,
+  and test helper stack.
+- Preserve the current fast/deep lane command names and CI intent:
+  `bun run test:e2e:fast` and `bun run test:e2e:deep` must remain the
+  operator-facing entry points.
+- Keep assertions deterministic. Prefer artefact scans, stable selectors,
+  DOM attributes, CSS custom-property presence, and narrow computed-style
+  checks over screenshot goldens.
+- Keep legacy compatibility classes attached where the migration already
+  preserves them. In particular, do not break `.tabs_list`,
+  `term_fit`, or `term_wrapper`.
+- Any change to developer workflow, required commands, or regression
+  expectations must be documented in `docs/developers-guide.md` during
+  implementation.
+- Do not mark roadmap item `9.2.4` done until all required gates,
+  including both E2E lanes, pass.
+- Follow the repository test-discipline instructions: do not run format,
+  lint, or test commands in parallel, and capture command output with
+  `tee` logs under `/tmp/`.
+
+## Tolerances (exception triggers)
+
+- Scope: if implementation needs more than 14 non-generated file edits,
+  pause and re-evaluate the plan before continuing.
+- Dependencies: if proving parity would require a new snapshot,
+  screenshot-diff, or CSS-inspection dependency, stop and escalate.
+- Test shape: if the fast lane cannot support the new artefact checks
+  without removing `playwright|spawn` driver compatibility, stop and
+  redesign instead of degrading the lane.
+- Deep lane: if parity checks remain flaky after two focused
+  stabilization passes, stop and present narrower alternatives.
+- Coverage gap: if the existing representative components are not enough
+  to prove one of the three migration patterns, document the missing
+  pattern and agree the next best surface before widening scope.
+- Iterations: if required gates still fail after three
+  fix-and-rerun cycles, stop and escalate with the failure set and log
+  paths.
+
+## Risks
+
+- Risk: minified or transformed artefacts may hide or reshape forbidden
+  strings, producing brittle string-only assertions.
+  Severity: medium
+  Likelihood: medium
+  Mitigation: combine forbidden-string scans with positive checks for the
+  expected CSS Modules output path and scan both synthetic bundles and
+  packaged artefacts.
+
+- Risk: global-selector parity is easy to overstate because some of the
+  compatibility contract is about class retention rather than pure visual
+  output.
+  Severity: medium
+  Likelihood: high
+  Mitigation: explicitly assert preserved legacy classes on the affected
+  DOM nodes and keep those checks separate from computed-style checks.
+
+- Risk: dynamic theme checks may become flaky if they depend on full
+  visual rendering rather than stable CSS variable plumbing.
+  Severity: medium
+  Likelihood: medium
+  Mitigation: assert CSS custom properties on representative wrapper
+  elements and then verify one narrow descendant computed style that
+  consumes the variable.
+
+- Risk: deep-lane coverage could grow into a broad visual-regression
+  framework.
+  Severity: medium
+  Likelihood: medium
+  Mitigation: keep the first pass limited to one deterministic style
+  parity scenario plus the existing terminal interaction path.
+
+## Progress
+
+- [x] (2026-04-23) Reviewed roadmap item `9.2.4`, its dependencies, the
+  renderer styling design notes, and the prior styled-jsx/CSS Modules
+  ExecPlans.
+- [x] (2026-04-23) Used two `wyvern` agents to survey documentation,
+  current coverage surfaces, and likely gaps without editing files or
+  running tests.
+- [x] (2026-04-23) Drafted this ExecPlan at
+  `docs/execplans/9-2-4-integration-and-regression-coverage-for-styled-jsx-removal.md`.
+- [ ] Await user approval.
+- [ ] Establish the failing regression checks that demonstrate the gap in
+  current coverage.
+- [ ] Extend unit/build contract coverage for packaged artefacts and CSS
+  Modules parity anchors.
+- [ ] Extend the fast E2E lane with packaged-output styled-jsx residue
+  checks.
+- [ ] Extend the deep E2E lane with one deterministic style-parity
+  scenario covering the three migration patterns.
+- [ ] Update `docs/developers-guide.md` and mark roadmap item `9.2.4`
+  done after the full validation sequence passes.
+- [ ] Record final outcomes, surprises, and retrospective notes here.
+
+## Surprises & Discoveries
+
+- Observation: the repository already has a useful styled-jsx removal
+  contract test in `test/unit/esbuild-migration-contracts.test.ts`, but
+  it only proves the synthetic fixture path, not packaged build output.
+  Impact: implementation should extend an existing contract rather than
+  create a parallel one.
+
+- Observation: the fast E2E lane already scans packaged files for
+  unresolved `@shared` runtime imports.
+  Impact: `test/e2e/electron.e2e.test.ts` and
+  `test/e2e/electron-e2e-helpers.ts` are the natural place to add
+  packaged `styled-jsx` residue checks.
+
+- Observation: the deep E2E lane currently proves only terminal input and
+  rendered output.
+  Impact: the new style-parity coverage should either extend that file in
+  a bounded way or split into a second deep-lane test file if size or
+  readability would suffer.
+
+## Decision Log
+
+- Decision: keep this task planning-only until explicit approval.
+  Rationale: the user requested an ExecPlan first, and the repository
+  guidance requires plan approval before implementation.
+  Date/Author: 2026-04-23 / Codex
+
+- Decision: reuse existing build-contract, fast-lane, and deep-lane
+  suites before introducing new top-level test infrastructure.
+  Rationale: the repository already has the right command structure and
+  helper stack; `9.2.4` is a coverage-hardening task, not a test-platform
+  rewrite.
+  Date/Author: 2026-04-23 / Codex
+
+- Decision: split responsibilities between lanes.
+  Rationale: fast-lane additions should focus on packaged artefact
+  cleanliness and cheap startup checks, while deep-lane additions should
+  carry the richer style-parity assertions.
+  Date/Author: 2026-04-23 / Codex
+
+## Plan of work
+
+## Milestone 1: Reproduce the missing coverage with focused failing checks
+
+Start by proving that the current repository still lacks the exact
+assertions required by `9.2.4`.
+
+1. Re-read the existing assertions in
+   `test/unit/esbuild-migration-contracts.test.ts`,
+   `test/e2e/electron.e2e.test.ts`, and
+   `test/e2e-deep/terminal-input-path.e2e.ts`.
+2. Add the smallest failing assertions that express the missing contract:
+   packaged-output `styled-jsx` residue scanning in the fast lane, and a
+   deep-lane style-parity scenario for the representative renderer
+   surfaces.
+3. Keep the initial failures narrow and diagnostic so the red phase tells
+   you exactly which contract is missing.
+
+Observable result: the new assertions fail before implementation changes
+and explain the missing `9.2.4` coverage in plain language.
+
+## Milestone 2: Strengthen unit and build-contract coverage
+
+Update `test/unit/esbuild-migration-contracts.test.ts` so it proves the
+build contract at two levels:
+
+1. Synthetic fixture bundling still strips `styled-jsx` runtime residue.
+2. Packaged output scanning can detect forbidden `styled-jsx` strings in
+   emitted renderer artefacts.
+
+If the current contract helper structure becomes hard to follow, extract a
+small test helper under `test/testUtils/` for scanning emitted JS/CSS
+files, but do not create a second contract suite.
+
+Extend the representative CSS Modules parity unit tests:
+
+1. `test/unit/search-box-css-modules.test.tsx` should assert the
+   `--search-*` CSS custom properties are present on the expected wrapper
+   and that one consumer element reflects the variable-driven styling
+   contract.
+2. `test/unit/new-tab.test.tsx` should assert the `--new-tab-border` and
+   `--new-tab-bg` variables are present and that the button/dropdown
+   remains wired to the CSS Modules classes without duplicate/empty class
+   segments.
+3. Global-selector compatibility should be asserted in the most natural
+   existing suite. Prefer extending a related unit suite; if none fits
+   cleanly, add a focused compatibility test under `test/unit/` that
+   proves `tabs_list`, `term_fit`, and `term_wrapper` still attach to the
+   expected DOM nodes.
+
+Observable result: the unit suite proves all three migration patterns in a
+fast, deterministic way and documents the exact DOM or artefact contract.
+
+## Milestone 3: Extend the fast E2E lane for packaged-output cleanliness
+
+Update `test/e2e/electron.e2e.test.ts` and, if needed,
+`test/e2e/electron-e2e-helpers.ts` so the fast lane fails when packaged
+artefacts contain forbidden `styled-jsx` runtime residue.
+
+Implementation rules:
+
+1. Reuse the existing packaged-file inspection pattern used for unresolved
+   `@shared` runtime imports.
+2. Scan the packaged renderer output set for:
+   `styled-jsx/style`, `styled-jsx`, and raw `<style jsx` or equivalent
+   uncompiled residue where that check is stable.
+3. Keep the scan helper path-driven and deterministic. It must produce a
+   clear error listing the offending files.
+4. Preserve `playwright|spawn` driver compatibility. Fast-lane additions
+   must not require a single driver mode.
+
+Observable result: `bun run test:e2e:fast` proves packaged startup is
+clean even before the app window is interacted with.
+
+## Milestone 4: Add one deep-lane style-parity scenario
+
+Extend the deep lane in `test/e2e-deep/`. If
+`test/e2e-deep/terminal-input-path.e2e.ts` would become unwieldy, create
+`test/e2e-deep/style-parity.e2e.ts` and keep the current interaction-path
+test separate.
+
+The deep-lane scenario must prove one representative example of each
+migration pattern:
+
+1. Local scoped styles:
+   assert a representative renderer surface renders with the expected CSS
+   Modules-owned class contract and non-empty computed styles.
+2. Global selector compatibility:
+   assert preserved legacy classes such as `.tabs_list`, `term_fit`, or
+   `term_wrapper` are present on the live renderer DOM where plugins or
+   custom CSS would expect them.
+3. Dynamic theme values:
+   assert representative wrapper elements expose the documented CSS custom
+   properties (`--search-*`, `--new-tab-*`, or equivalent) and that a
+   live descendant style consumes them.
+
+Prefer DOM evaluation and narrow `getComputedStyle(...)` checks over image
+comparison. Keep selectors stable and close to existing accessibility or
+component contracts.
+
+Observable result: `bun run test:e2e:deep` proves a real packaged
+renderer still satisfies the CSS Modules migration contract after bridge
+removal.
+
+## Milestone 5: Documentation and roadmap closure
+
+Once the code and tests are green, update the documentation surfaces that
+encode developer expectations:
+
+1. Update `docs/developers-guide.md` with a concise `9.2.4` regression
+   checklist covering:
+   - the representative CSS Modules parity surfaces,
+   - the forbidden packaged-output `styled-jsx` scan,
+   - the fact that both fast and deep lanes now participate in renderer
+     styling safety.
+2. Update `docs/roadmap.md` to mark `9.2.4` done only after all required
+   validation succeeds.
+3. If implementation clarifies a previously stale bridge-era statement in a
+   touched design or hyper-codebase document, update it in the same
+   change. Do not start a broad docs sweep.
+
+Observable result: a future developer can find both the commands and the
+reason for running them without opening historical ExecPlans.
+
+## Validation and acceptance
+
+During implementation, capture every required command with `tee` and keep
+the logs. Use the branch-local naming pattern from `AGENTS.md`, for
+example `/tmp/<action>-$(get-project)-$(git branch --show).out`.
+
+Mandatory repository gates:
+
+```bash
+bun install 2>&1 | tee /tmp/bun-install-$(get-project)-$(git branch --show).out
+make build 2>&1 | tee /tmp/build-$(get-project)-$(git branch --show).out
+make check-fmt 2>&1 | tee /tmp/check-fmt-$(get-project)-$(git branch --show).out
+make lint 2>&1 | tee /tmp/lint-$(get-project)-$(git branch --show).out
+make test 2>&1 | tee /tmp/test-$(get-project)-$(git branch --show).out
+```
+
+Feature-specific regression checks:
+
+```bash
+bun run test:e2e:fast 2>&1 | tee /tmp/test-e2e-fast-$(get-project)-$(git branch --show).out
+bun run test:e2e:deep 2>&1 | tee /tmp/test-e2e-deep-$(get-project)-$(git branch --show).out
+```
+
+Documentation gates because this work updates Markdown:
+
+```bash
+bunx markdownlint-cli2 "docs/**/*.md" 2>&1 | tee /tmp/markdownlint-$(get-project)-$(git branch --show).out
+nixie --no-sandbox 2>&1 | tee /tmp/nixie-$(get-project)-$(git branch --show).out
+```
+
+Acceptance criteria:
+
+1. The new or expanded unit tests explicitly cover local styles, global
+   selectors, and dynamic theme values.
+2. The fast lane fails if packaged output contains `styled-jsx` residue.
+3. The deep lane proves live packaged-renderer style parity using stable
+   DOM/computed-style assertions.
+4. `docs/developers-guide.md` reflects the final workflow.
+5. `docs/roadmap.md` marks `9.2.4` done only after all commands above
+   pass.
+
+## Outcomes & Retrospective
+
+Pending implementation approval.

--- a/docs/execplans/9-2-4-integration-and-regression-coverage-for-styled-jsx-removal.md
+++ b/docs/execplans/9-2-4-integration-and-regression-coverage-for-styled-jsx-removal.md
@@ -5,7 +5,7 @@ This ExecPlan (execution plan) is a living document. The sections
 Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be
 kept up to date as work proceeds.
 
-Status: DRAFT
+Status: COMPLETE
 
 ## Purpose / big picture
 
@@ -39,8 +39,7 @@ Success is observable when:
 5. `docs/roadmap.md` marks item `9.2.4` done only after the full
    validation sequence passes.
 
-This document is planning-only. Implementation must not begin until the
-user explicitly approves this ExecPlan.
+Implementation completed on 2026-04-23 after explicit user approval.
 
 ## Documentation and skills
 
@@ -196,18 +195,28 @@ behaviour cleanly.
   running tests.
 - [x] (2026-04-23) Drafted this ExecPlan at
   `docs/execplans/9-2-4-integration-and-regression-coverage-for-styled-jsx-removal.md`.
-- [ ] Await user approval.
-- [ ] Establish the failing regression checks that demonstrate the gap in
-  current coverage.
-- [ ] Extend unit/build contract coverage for packaged artefacts and CSS
-  Modules parity anchors.
-- [ ] Extend the fast E2E lane with packaged-output styled-jsx residue
-  checks.
-- [ ] Extend the deep E2E lane with one deterministic style-parity
-  scenario covering the three migration patterns.
-- [ ] Update `docs/developers-guide.md` and mark roadmap item `9.2.4`
-  done after the full validation sequence passes.
-- [ ] Record final outcomes, surprises, and retrospective notes here.
+- [x] (2026-04-23) User approved implementation in this worktree and the
+  plan moved to `IN PROGRESS`.
+- [x] (2026-04-23) Re-read the existing unit, fast-lane, and deep-lane
+  assertions to confirm that `9.2.4` was still a coverage gap rather than
+  a production regression.
+- [x] (2026-04-23) Extended unit/build coverage with packaged-output
+  residue scanning, `.tabs_list` CSS selector preservation, `SearchBox`
+  theme-variable assertions, `NewTab` theme-variable assertions, and
+  `Term` legacy-class render assertions.
+- [x] (2026-04-23) Added a shared packaged-output residue helper and
+  wired the fast E2E lane to fail before launch if
+  `dist/app/renderer/bundle.js` or `bundle.css` contains forbidden
+  styled-jsx residue.
+- [x] (2026-04-23) Added `test/e2e-deep/style-parity.e2e.ts` to verify
+  themed new-tab styling plus live `term_fit` / `term_wrapper`
+  compatibility classes in the packaged renderer.
+- [x] (2026-04-23) Updated `docs/developers-guide.md` with the `9.2.4`
+  regression checklist and marked roadmap item `9.2.4` complete.
+- [x] (2026-04-23) Ran the full repository validation stack, including
+  the fast and deep E2E lanes under `xvfb-run --auto-servernum` in this
+  WSL environment, and recorded the remaining environment observations
+  below.
 
 ## Surprises & Discoveries
 
@@ -223,11 +232,37 @@ behaviour cleanly.
   `test/e2e/electron-e2e-helpers.ts` are the natural place to add
   packaged `styled-jsx` residue checks.
 
+- Observation: `.tabs_list` is preserved through the selector contract in
+  `lib/components/tabs.module.css`, not by attaching the literal class to
+  the `<ul>` at render time.
+  Impact: coverage should assert selector preservation for tabs, while
+  `.term_fit` and `.term_wrapper` remain the DOM-attached legacy classes.
+
 - Observation: the deep E2E lane currently proves only terminal input and
   rendered output.
   Impact: the new style-parity coverage should either extend that file in
   a bounded way or split into a second deep-lane test file if size or
   readability would suffer.
+
+- Observation: direct Linux/WSL E2E launches without an X display crash
+  before `[e2e] renderer-ready`, even when the residue scan passes.
+  Impact: the repository's documented `xvfb-run --auto-servernum` wrapper
+  from `docs/testing-wsl2.md` is required for reliable local E2E
+  validation in this environment.
+
+- Observation: `nixie --no-sandbox` also depends on Puppeteer's pinned
+  `chrome-headless-shell@131.0.6778.204`, not just any installed Chrome
+  build.
+  Impact: local Mermaid validation in this environment required
+  installing that exact browser build before the documentation gate would
+  pass.
+
+- Observation: the first `make build` attempt failed during
+  `electron-builder` packaging with a transient JSON parse error while
+  AppImage metadata was being emitted.
+  Impact: a single rerun completed successfully with no code changes,
+  so the failure appears to be environmental or tool-level noise rather
+  than a regression introduced by this work.
 
 ## Decision Log
 
@@ -247,6 +282,30 @@ behaviour cleanly.
   Rationale: fast-lane additions should focus on packaged artefact
   cleanliness and cheap startup checks, while deep-lane additions should
   carry the richer style-parity assertions.
+  Date/Author: 2026-04-23 / Codex
+
+- Decision: treat global-selector compatibility as two related but
+  distinct contracts.
+  Rationale: `Term` still exposes literal legacy classes in the live DOM,
+  while `Tabs` preserves `.tabs_list` through a shared CSS selector in the
+  module stylesheet. The assertions should reflect the actual migration
+  model instead of assuming every legacy selector still appears as a DOM
+  class name.
+  Date/Author: 2026-04-23 / Codex
+
+- Decision: keep the new deep-lane parity assertions in a dedicated
+  `test/e2e-deep/style-parity.e2e.ts` file.
+  Rationale: `terminal-input-path.e2e.ts` already owns the interaction
+  path. A second deep-lane file keeps the style contract readable and
+  avoids mixing unrelated failure modes in one long test.
+  Date/Author: 2026-04-23 / Codex
+
+- Decision: use DOM selectors for the new-tab parity scenario instead of
+  relying on Playwright accessibility-role lookup.
+  Rationale: the packaged renderer reliably exposes the DOM contract
+  (`button[title="New Tab"]` and `button[aria-label="New Tab"]`), while
+  `getByRole(...)` proved brittle in this environment even after the
+  window finished loading.
   Date/Author: 2026-04-23 / Codex
 
 ## Plan of work
@@ -416,4 +475,40 @@ Acceptance criteria:
 
 ## Outcomes & Retrospective
 
-Pending implementation approval.
+Implemented the `9.2.4` regression contract with focused coverage rather
+than production-code churn:
+
+1. Added shared styled-jsx residue scanning in
+   `test/testUtils/styled-jsx-residue.ts` and used it to strengthen both
+   unit/build coverage and the fast E2E lane.
+2. Extended unit coverage so the repository now explicitly checks:
+   packaged-output residue detection, preserved `.tabs_list` CSS
+   selector output, `SearchBox` theme custom properties, `NewTab` theme
+   custom properties, and `Term` legacy DOM classes.
+3. Added `test/e2e-deep/style-parity.e2e.ts` so the deep lane now
+   validates a live packaged renderer for local CSS Module styling,
+   dynamic theme values, and preserved terminal compatibility classes.
+4. Updated `docs/developers-guide.md` and `docs/roadmap.md` so the
+   regression workflow is discoverable outside this ExecPlan.
+
+Validation summary:
+
+- `bun fmt`: pass
+- `bun install`: pass
+- `make build`: pass on rerun after one transient packaging failure
+- `make check-fmt`: pass
+- `make lint`: pass
+- `make test`: pass
+- `xvfb-run --auto-servernum bun run test:e2e:fast`: pass
+- `xvfb-run --auto-servernum bun run test:e2e:deep`: pass
+- `bunx markdownlint-cli2 "docs/**/*.md"`: pass
+- `nixie --no-sandbox`: pass after installing Puppeteer's pinned
+  `chrome-headless-shell@131.0.6778.204`
+
+Lessons learned:
+
+- The deepest styled-jsx-removal contract is better expressed as a mix of
+  artefact scanning, DOM class assertions, and narrow computed-style
+  checks than as a visual-regression harness.
+- WSL validation for Electron and Mermaid needs explicit browser/display
+  prerequisites; once those are present, the new coverage remains stable.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -526,13 +526,13 @@ changes remain in section 7 and are out of scope here.
     pushes to `master` and `canary`.
   - [x] Retain deep-lane failure artefacts (stdout/stderr, renderer console,
     screenshots, and traces).
-- [ ] 9.2.4. Add integration and end-to-end regression coverage for styled-jsx
+- [x] 9.2.4. Add integration and end-to-end regression coverage for styled-jsx
   removal and CSS Modules parity. Requires 1.4.17 and 9.2.3.
-  - [ ] Add assertions that renderer startup and bundled output contain no
+  - [x] Add assertions that renderer startup and bundled output contain no
     unresolved styled-jsx runtime imports.
-  - [ ] Add migration-focused parity checks for local styles, global selectors,
+  - [x] Add migration-focused parity checks for local styles, global selectors,
     and dynamic theme values.
-  - [ ] Success criteria: fast and deep end-to-end lanes pass without style
+  - [x] Success criteria: fast and deep end-to-end lanes pass without style
     regressions after the bridge is removed.
 
 ### 9.3. Unit-test isolation and concurrency safety

--- a/test/e2e-deep/style-parity.e2e.ts
+++ b/test/e2e-deep/style-parity.e2e.ts
@@ -1,0 +1,194 @@
+/**
+ * @file Deep E2E assertion for CSS Modules parity after styled-jsx removal.
+ * Purpose: Validate a live packaged renderer still preserves themed new-tab
+ * styling plus legacy terminal compatibility classes.
+ */
+import fs from 'node:fs/promises';
+
+import {_electron} from 'playwright';
+import {expect, test} from 'playwright/test';
+
+import {
+  createIsolatedE2EEnvironment,
+  resolveLaunchConfig,
+  startRendererConsoleMonitor,
+  waitForRendererReady,
+  withTimeout
+} from '../e2e/electron-e2e-helpers';
+
+const launchTimeoutMs = 20_000;
+const windowTimeoutMs = 10_000;
+const rendererReadyTimeoutMs = 12_000;
+const closeTimeoutMs = 5_000;
+
+test('preserves CSS Modules style parity for themed new-tab UI and terminal compatibility classes', async ({
+  page: _page
+}, testInfo) => {
+  const {pathToBinary, launchArgs} = resolveLaunchConfig();
+  await fs.access(pathToBinary);
+  const isolatedEnvironment = await createIsolatedE2EEnvironment();
+
+  const app = await withTimeout(
+    _electron.launch({
+      executablePath: pathToBinary,
+      args: launchArgs,
+      env: isolatedEnvironment.env,
+      timeout: launchTimeoutMs
+    }),
+    launchTimeoutMs
+  );
+
+  const process = app.process();
+  let stdoutLog = '';
+  let stderrLog = '';
+  const rendererConsoleLog: string[] = [];
+  process?.stdout?.on('data', (chunk) => {
+    stdoutLog += chunk.toString();
+  });
+  process?.stderr?.on('data', (chunk) => {
+    stderrLog += chunk.toString();
+  });
+
+  let monitor: ReturnType<typeof startRendererConsoleMonitor> | null = null;
+  let mainWindow: Awaited<ReturnType<typeof app.firstWindow>> | null = null;
+
+  try {
+    mainWindow = await withTimeout(app.firstWindow(), windowTimeoutMs);
+    monitor = startRendererConsoleMonitor(mainWindow);
+    mainWindow.on('console', (message) => {
+      rendererConsoleLog.push(`[${message.type()}] ${message.text()}`);
+    });
+
+    await waitForRendererReady(mainWindow, rendererReadyTimeoutMs);
+    await mainWindow.evaluate(() => {
+      const newTabButton = document.querySelector<HTMLButtonElement>(
+        'button[title="New Tab"], button[aria-label="New Tab"]'
+      );
+      if (!newTabButton) {
+        throw new Error('[e2e] style parity check failed: missing New Tab button');
+      }
+      newTabButton.click();
+    });
+    await expect
+      .poll(async () => await mainWindow?.evaluate(() => document.querySelector('[role="menu"]') !== null), {
+        timeout: rendererReadyTimeoutMs
+      })
+      .toBe(true);
+
+    const styleParity = await mainWindow.evaluate(() => {
+      const fail = (message: string): never => {
+        throw new Error(`[e2e] style parity check failed: ${message}`);
+      };
+
+      const resolveCssColor = (value: string) => {
+        const probe = document.createElement('div');
+        probe.style.color = value;
+        document.body.appendChild(probe);
+        const resolved = getComputedStyle(probe).color;
+        probe.remove();
+        return resolved;
+      };
+
+      const newTabButton = document.querySelector<HTMLButtonElement>('button[aria-label="New Tab"]');
+      if (!newTabButton) {
+        fail('missing New Tab button');
+      }
+
+      const newTabWrapper = newTabButton.parentElement;
+      if (!newTabWrapper) {
+        fail('missing New Tab wrapper');
+      }
+
+      const dropdown = document.querySelector<HTMLElement>('[role="menu"]');
+      if (!dropdown) {
+        fail('missing profile dropdown after opening the New Tab menu');
+      }
+
+      const dropdownItem = document.querySelector<HTMLElement>('[role="menuitem"]');
+      if (!dropdownItem) {
+        fail('missing profile dropdown item');
+      }
+
+      const termFit = document.querySelector<HTMLElement>('.term_fit');
+      if (!termFit) {
+        fail('missing `.term_fit` legacy compatibility class');
+      }
+
+      const termWrapper = document.querySelector<HTMLElement>('.term_wrapper');
+      if (!termWrapper) {
+        fail('missing `.term_wrapper` legacy compatibility class');
+      }
+
+      const wrapperStyle = getComputedStyle(newTabWrapper);
+      const dropdownStyle = getComputedStyle(dropdown);
+      const dropdownItemStyle = getComputedStyle(dropdownItem);
+      const expectedBorderColor = resolveCssColor(wrapperStyle.getPropertyValue('--new-tab-border').trim());
+      const expectedBackgroundColor = resolveCssColor(wrapperStyle.getPropertyValue('--new-tab-bg').trim());
+
+      return {
+        newTabButtonClassName: newTabButton.className,
+        dropdownClassName: dropdown.className,
+        dropdownItemClassName: dropdownItem.className,
+        termFitClassName: termFit.className,
+        termWrapperClassName: termWrapper.className,
+        newTabBorderVar: wrapperStyle.getPropertyValue('--new-tab-border').trim(),
+        newTabBackgroundVar: wrapperStyle.getPropertyValue('--new-tab-bg').trim(),
+        dropdownPosition: dropdownStyle.position,
+        dropdownTop: dropdownStyle.top,
+        dropdownZIndex: dropdownStyle.zIndex,
+        dropdownBackgroundColor: dropdownStyle.backgroundColor,
+        dropdownBorderColor: dropdownStyle.borderLeftColor,
+        dropdownItemLineHeight: dropdownItemStyle.lineHeight,
+        dropdownItemBorderColor: dropdownItemStyle.borderBottomColor,
+        expectedBorderColor,
+        expectedBackgroundColor
+      };
+    });
+
+    expect(styleParity.newTabButtonClassName).not.toBe('');
+    expect(styleParity.dropdownClassName).not.toBe('');
+    expect(styleParity.dropdownItemClassName).not.toBe('');
+    expect(styleParity.newTabBorderVar).not.toBe('');
+    expect(styleParity.newTabBackgroundVar).not.toBe('');
+    expect(styleParity.dropdownPosition).toBe('absolute');
+    expect(styleParity.dropdownTop).toBe('33px');
+    expect(styleParity.dropdownZIndex).toBe('1000');
+    expect(styleParity.dropdownBackgroundColor).toBe(styleParity.expectedBackgroundColor);
+    expect(styleParity.dropdownBorderColor).toBe(styleParity.expectedBorderColor);
+    expect(styleParity.dropdownItemBorderColor).toBe(styleParity.expectedBorderColor);
+    expect(styleParity.dropdownItemLineHeight).toBe('34px');
+    expect(styleParity.termFitClassName).toContain('term_fit');
+    expect(styleParity.termWrapperClassName).toContain('term_wrapper');
+    expect(monitor.criticalErrors).toHaveLength(0);
+  } finally {
+    monitor?.stop();
+
+    await testInfo.attach('electron-stdout.log', {
+      body: stdoutLog || 'No stdout output captured.',
+      contentType: 'text/plain'
+    });
+    await testInfo.attach('electron-stderr.log', {
+      body: stderrLog || 'No stderr output captured.',
+      contentType: 'text/plain'
+    });
+    await testInfo.attach('renderer-console.log', {
+      body: rendererConsoleLog.join('\n') || 'No renderer console output captured.',
+      contentType: 'text/plain'
+    });
+
+    if (mainWindow && testInfo.status !== testInfo.expectedStatus) {
+      const screenshot = await mainWindow.screenshot({fullPage: true});
+      await testInfo.attach('renderer-failure.png', {
+        body: screenshot,
+        contentType: 'image/png'
+      });
+    }
+
+    try {
+      await withTimeout(app.close(), closeTimeoutMs);
+    } catch {
+      process?.kill('SIGKILL');
+    }
+    await isolatedEnvironment.cleanup();
+  }
+});

--- a/test/e2e/electron.e2e.test.ts
+++ b/test/e2e/electron.e2e.test.ts
@@ -13,6 +13,7 @@ import fs from 'fs-extra';
 import {_electron} from 'playwright';
 import type {ElectronApplication} from 'playwright';
 
+import {assertPackagedRendererOutputHasNoStyledJsxResidue} from './renderer-artifact-contracts';
 import {
   createIsolatedE2EEnvironment,
   extractRendererErrorMessage,
@@ -460,6 +461,7 @@ e2eTest(
     const context = await setupTestContext();
     try {
       await assertTargetHasNoUnresolvedSharedRuntimeImports();
+      await assertPackagedRendererOutputHasNoStyledJsxResidue();
       const {pathToBinary, launchArgs} = resolveLaunchConfig();
       if (!(await fs.pathExists(pathToBinary))) {
         throw new Error(`Expected packaged app binary at ${pathToBinary}. Run bun run dist first.`);
@@ -499,6 +501,7 @@ e2eTest(
     const context = await setupTestContext();
     try {
       await assertTargetHasNoUnresolvedSharedRuntimeImports();
+      await assertPackagedRendererOutputHasNoStyledJsxResidue();
       context.spawned = spawn(process.execPath, developmentAppLaunchArgs, {
         cwd: process.cwd(),
         env: {

--- a/test/e2e/renderer-artifact-contracts.ts
+++ b/test/e2e/renderer-artifact-contracts.ts
@@ -1,0 +1,16 @@
+/** @file Fast-E2E contracts for packaged renderer artefact cleanliness. */
+import {collectStyledJsxResidueMatches, formatStyledJsxResidueMatches} from '../testUtils/styled-jsx-residue';
+
+const packagedRendererArtefacts = ['dist/app/renderer/bundle.js', 'dist/app/renderer/bundle.css'] as const;
+
+export const assertPackagedRendererOutputHasNoStyledJsxResidue = async () => {
+  const matches = await collectStyledJsxResidueMatches(packagedRendererArtefacts);
+  if (matches.length === 0) {
+    return;
+  }
+
+  throw new Error(
+    'Packaged renderer output still contains styled-jsx residue in: ' +
+      formatStyledJsxResidueMatches(matches).join(', ')
+  );
+};

--- a/test/testUtils/styled-jsx-residue.ts
+++ b/test/testUtils/styled-jsx-residue.ts
@@ -1,0 +1,45 @@
+/** @file Shared helpers for detecting forbidden styled-jsx residue in built artefacts. */
+import fs from 'node:fs/promises';
+
+export type ForbiddenResiduePattern = Readonly<{
+  label: string;
+  pattern: RegExp;
+}>;
+
+export type StyledJsxResidueMatch = Readonly<{
+  relativePath: string;
+  labels: string[];
+}>;
+
+export const styledJsxResiduePatterns: readonly ForbiddenResiduePattern[] = [
+  {label: 'styled-jsx/style', pattern: /styled-jsx\/style/},
+  {label: 'styled-jsx', pattern: /styled-jsx/},
+  {label: '<style jsx', pattern: /<style\s+jsx\b/i}
+];
+
+const findMatchingLabels = (contents: string, patterns: readonly ForbiddenResiduePattern[]) =>
+  patterns.filter(({pattern}) => pattern.test(contents)).map(({label}) => label);
+
+export const inspectFileForStyledJsxResidue = async (
+  relativePath: string,
+  patterns: readonly ForbiddenResiduePattern[] = styledJsxResiduePatterns
+) => {
+  const contents = await fs.readFile(relativePath, 'utf8');
+  return {
+    relativePath,
+    labels: findMatchingLabels(contents, patterns)
+  } satisfies StyledJsxResidueMatch;
+};
+
+export const collectStyledJsxResidueMatches = async (
+  relativePaths: readonly string[],
+  patterns: readonly ForbiddenResiduePattern[] = styledJsxResiduePatterns
+) => {
+  const inspections = await Promise.all(
+    relativePaths.map((relativePath) => inspectFileForStyledJsxResidue(relativePath, patterns))
+  );
+  return inspections.filter((inspection) => inspection.labels.length > 0);
+};
+
+export const formatStyledJsxResidueMatches = (matches: readonly StyledJsxResidueMatch[]) =>
+  matches.map(({relativePath, labels}) => `${relativePath} [${labels.join(', ')}]`);

--- a/test/unit/esbuild-migration-contracts.test.ts
+++ b/test/unit/esbuild-migration-contracts.test.ts
@@ -17,6 +17,7 @@ import {
   createRendererExternalsPlugin,
   resolveRendererExternalPath
 } from '../../build/esbuild/esbuild-plugins/renderer-externals-plugin';
+import {collectStyledJsxResidueMatches, formatStyledJsxResidueMatches} from '../testUtils/styled-jsx-residue';
 
 /** Creates an isolated temporary directory for build fixture tests. */
 const createTempDir = () => mkdtemp(path.join(tmpdir(), 'velocetty-esbuild-'));
@@ -87,6 +88,31 @@ test('translation: CSS Modules are bundled with scoped class names in renderer b
     expect(classMapMatch).toBeTruthy();
     // The scoped class name follows the expected pattern (module prefix + underscore + class name)
     expect(classMapMatch?.[1]).toMatch(/^fixture_searchBox$/);
+  } finally {
+    await rm(rootDir, {recursive: true, force: true});
+  }
+});
+
+test('translation: renderer CSS bundle preserves the legacy tabs_list selector contract', async () => {
+  const rootDir = await createTempDir();
+  try {
+    const entryPoint = path.join(rootDir, 'fixture.ts');
+    await writeFixtureFile(
+      entryPoint,
+      `import ${JSON.stringify(path.join(process.cwd(), 'lib/components/tabs.module.css'))};`
+    );
+
+    const rendererOptions = createRendererBuildOptions('development', rootDir);
+    const buildResult = await runEsbuildBuild({
+      ...rendererOptions,
+      entryPoints: [entryPoint],
+      bundle: true,
+      write: false,
+      outfile: path.join(rootDir, 'bundle.js')
+    });
+
+    const cssOutput = buildResult.outputFiles.find((file) => file.path.endsWith('.css'))?.text ?? '';
+    expect(cssOutput).toContain('.tabs_list');
   } finally {
     await rm(rootDir, {recursive: true, force: true});
   }
@@ -334,6 +360,27 @@ test('translation: renderer build removes styled-jsx syntax', async () => {
     // transformation, confirming the build succeeded and produced valid output.
     expect(bundleOutput.includes('react')).toBe(true);
     expect(bundleOutput.includes('createElement') || bundleOutput.includes('jsx')).toBe(true);
+  } finally {
+    await rm(rootDir, {recursive: true, force: true});
+  }
+});
+
+test('translation: packaged-output residue scan reports offending renderer artefacts', async () => {
+  const rootDir = await createTempDir();
+  try {
+    const cleanFile = path.join(rootDir, 'dist', 'app', 'renderer', 'bundle.css');
+    const offendingFile = path.join(rootDir, 'dist', 'app', 'renderer', 'bundle.js');
+    await writeFixtureFile(cleanFile, '.searchBox { color: var(--search-fg); }');
+    await writeFixtureFile(
+      offendingFile,
+      ["import 'styled-jsx/style';", 'export const stale = "<style jsx>{`.x { color: red; }`}</style>";'].join('\n')
+    );
+
+    const matches = await collectStyledJsxResidueMatches([cleanFile, offendingFile]);
+
+    expect(formatStyledJsxResidueMatches(matches)).toEqual([
+      `${offendingFile} [styled-jsx/style, styled-jsx, <style jsx]`
+    ]);
   } finally {
     await rm(rootDir, {recursive: true, force: true});
   }

--- a/test/unit/new-tab.test.tsx
+++ b/test/unit/new-tab.test.tsx
@@ -165,3 +165,46 @@ test('closes the dropdown when focus leaves the component boundary', async () =>
     cleanup();
   }
 });
+
+test('exposes CSS custom properties and CSS Module classes for the trigger and dropdown', async () => {
+  const {cleanup, container, root} = await renderNewTab();
+
+  try {
+    const button = container.querySelector('button');
+    const wrapper = button?.parentElement as HTMLDivElement | null;
+    expect(button).toBeTruthy();
+    expect(wrapper).toBeTruthy();
+
+    if (!button || !wrapper) {
+      throw new Error('Expected new-tab trigger and wrapper to be present');
+    }
+
+    expect(button.className).toContain('newTab');
+    expect(button.className).not.toContain('  ');
+    expect(wrapper.style.getPropertyValue('--new-tab-border')).toBe('#333');
+    expect(wrapper.style.getPropertyValue('--new-tab-bg')).toBe('#000');
+
+    await act(async () => {
+      button.dispatchEvent(new window.MouseEvent('click', {bubbles: true}));
+      await waitFor(0);
+    });
+
+    const dropdown = container.querySelector<HTMLElement>('[role="menu"]');
+    const menuItem = container.querySelector<HTMLButtonElement>('button[role="menuitem"]');
+    expect(dropdown).toBeTruthy();
+    expect(menuItem).toBeTruthy();
+
+    if (!dropdown || !menuItem) {
+      throw new Error('Expected new-tab dropdown and menu item to be present');
+    }
+
+    expect(dropdown.className).toContain('profileDropdown');
+    expect(menuItem.className).toContain('profileDropdownItem');
+  } finally {
+    await act(async () => {
+      root.unmount();
+      await waitFor(0);
+    });
+    cleanup();
+  }
+});

--- a/test/unit/search-box-css-modules.test.tsx
+++ b/test/unit/search-box-css-modules.test.tsx
@@ -366,3 +366,32 @@ test.serial('SearchBox output element carries aria-live polite for screen-reader
     await teardown();
   }
 });
+
+test.serial('SearchBox exposes CSS custom properties and CSS Module classes for themed controls', async () => {
+  const {container, teardown} = await renderSearchBox();
+  try {
+    const searchContainer = container.firstElementChild;
+    const searchInput = container.querySelector<HTMLInputElement>('input[type="text"]');
+    const toggleButton = container.querySelector<HTMLButtonElement>(`button[title="${defaultLabels.matchCaseLabel}"]`);
+
+    expect(searchContainer).toBeTruthy();
+    expect(searchInput).toBeTruthy();
+    expect(toggleButton).toBeTruthy();
+
+    if (!searchContainer || !searchInput || !toggleButton) {
+      throw new Error('Expected search container, input, and toggle button to be present');
+    }
+
+    expect(searchContainer.className).toContain('searchContainer');
+    expect(searchContainer.className).not.toContain('  ');
+    expect(searchContainer.style.getPropertyValue('--search-bg')).toBe(defaultColors.backgroundColor);
+    expect(searchContainer.style.getPropertyValue('--search-border')).toBe(defaultColors.borderColor);
+    expect(searchContainer.style.getPropertyValue('--search-fg')).toBe(defaultColors.foregroundColor);
+    expect(searchContainer.style.getPropertyValue('--search-selection')).toBe(defaultColors.selectionColor);
+    expect(searchContainer.style.getPropertyValue('--search-font')).toBe(defaultColors.font);
+    expect(searchInput.className).toContain('searchInput');
+    expect(toggleButton.className).toContain('searchButton');
+  } finally {
+    await teardown();
+  }
+});

--- a/test/unit/term-report-renderer.test.ts
+++ b/test/unit/term-report-renderer.test.ts
@@ -1,6 +1,7 @@
 /** @file Verifies Term.reportRenderer emits via transport with deduplication. */
 import {randomUUID} from 'node:crypto';
 
+import {Children, isValidElement} from 'react';
 import {describe, expect, mock, spyOn, test} from 'bun:test';
 import {
   LONG_FRAME_THRESHOLD_MS,
@@ -218,6 +219,30 @@ describe('Term.reportRenderer transport emit', () => {
         type: 'Canvas',
         runtimeMetrics
       });
+    }));
+
+  test('render keeps legacy term_fit and term_wrapper classes on renderer nodes', () =>
+    withTermTestHarness(({createTermInstanceForWebGLFallbackTest}) => {
+      const term = createTermInstanceForWebGLFallbackTest('uid-render-classes');
+      const rendered = term.render();
+
+      if (!isValidElement(rendered)) {
+        throw new Error('Expected Term.render() to return a React element');
+      }
+
+      expect(rendered.props.className).toContain('term_fit');
+
+      const children = Children.toArray(rendered.props.children);
+      const termWrapper = children.find(
+        (child) => isValidElement(child) && child.props.className?.includes('term_wrapper')
+      );
+
+      if (!termWrapper || !isValidElement(termWrapper)) {
+        throw new Error('Expected rendered Term output to include the term wrapper node');
+      }
+
+      expect(termWrapper.props.className).toContain('term_fit');
+      expect(termWrapper.props.className).toContain('term_wrapper');
     }));
 });
 


### PR DESCRIPTION
Draft the `9.2.4` execution plan for styled-jsx removal regression coverage and CSS Modules parity.

Keep the plan self-contained, tie it to the existing migration and E2E strategy documents, and record that implementation stays blocked until explicit approval.

## Summary by Sourcery

Documentation:
- Introduce a detailed ExecPlan markdown document outlining the strategy, milestones, constraints, risks, and acceptance criteria for verifying styled-jsx removal and CSS Modules parity across unit tests and E2E lanes.