### PR TITLE
Align roadmap with the roadmap grammar

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -12,6 +12,12 @@ Scope notes:
 - Dependencies are called out explicitly using dotted notation.
 - Each task references the design or PRD section it implements.
 
+## Out of scope for this roadmap
+
+- Marketplace, payments, or plugin monetization flows.
+- Multi-user collaboration or shared terminal sessions.
+- Persisting full terminal scrollback across restarts.
+
 ## 1. Core scaffolding and shared contracts
 
 ### 1.1. Repository split and build foundations
@@ -584,7 +590,7 @@ changes remain in section 7 and are out of scope here.
     `test/unit/v8-snapshot-util.test.ts`.
   - [x] Remove config-path, plugin-config, and mocked module bleed in
     `test/unit/cli-api-behaviour.test.ts`.
-- [x] Success criteria: targeted
+  - [x] Success criteria: targeted
     `bun test --concurrent test/unit/v8-snapshot-util.test.ts test/unit/cli-api-behaviour.test.ts`
     passes 100 consecutive local runs with stable config and snapshot
     expectations.
@@ -623,9 +629,3 @@ changes remain in section 7 and are out of scope here.
     `bun test --concurrent --randomize --seed 20260306 test/unit` all pass,
     and then `bun install`, `make build`, `make check-fmt`, `make lint`, and
     `make test` pass with `--concurrent` in the default unit-test path.
-
-## Out of scope for this roadmap
-
-- Marketplace, payments, or plugin monetization flows.
-- Multi-user collaboration or shared terminal sessions.
-- Persisting full terminal scrollback across restarts.


### PR DESCRIPTION
## Summary

This branch aligns [docs/roadmap.md](https://github.com/leynos/velocetty/blob/docs/roadmap-syntax/docs/roadmap.md) with the mapsplice roadmap grammar. The checker failed with "expected a numbered task prefix in `Success criteria: targeted ...`": the criteria checklist item for task 9.3.5 sat at step level rather than nested under its task. A second latent violation — the unnumbered `## Out of scope for this roadmap` heading after the final phase — is also resolved.

## Review walkthrough

- Start with [docs/roadmap.md](https://github.com/leynos/velocetty/blob/docs/roadmap-syntax/docs/roadmap.md) to see the two changes: the `Success criteria: targeted ...` item under task 9.3.5 indented two spaces so it nests like the criteria items of every sibling task (its continuation lines were already indented for the nested position, so this was an indentation slip); and the "Out of scope for this roadmap" section moved verbatim from the end of the document into the preamble, before phase 1.

## Validation

- `mapsplice append docs/roadmap.md <dummy-phase>`: exit 0 (grammar-clean)
- `bunx markdownlint-cli2 docs/roadmap.md`: 0 errors

## Notes

- The out-of-scope section is scope-explanatory front matter, so it was moved into the preamble (where unnumbered level-2 headings are valid) alongside the existing scope notes, rather than being demoted to a bold paragraph or converted into a phase. Its wording is unchanged and no roadmap items were reordered or renumbered.

## Summary by Sourcery

Align the roadmap document with the mapsplice roadmap grammar by fixing task nesting and relocating scope notes.

Documentation:
- Move the "Out of scope for this roadmap" section into the preamble ahead of phase 1 to match roadmap grammar expectations.
- Nest the "Success criteria: targeted ..." checklist item under task 9.3.5 so its success criteria align with sibling tasks.

## References

- [Lody session](https://lody.ai/leynos/sessions/47525a5a-c3e1-430f-b92c-1c380f909608)
