### PR TITLE
Add a zero-tolerance TypeDoc documentation gate

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -99,6 +99,7 @@ jobs:
       - name: Run Makefile lint and unit-test gates
         run: |
           make lint
+          make docs-check
           make test
       - name: Getting Build Icon
         if: github.ref == 'refs/heads/canary' || github.base_ref == 'canary'

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all check-fmt typecheck lint test coverage build build-fast clean \
+.PHONY: all check-fmt typecheck docs-check lint test coverage build build-fast clean \
 	markdownlint nixie spelling spelling-config spelling-config-write \
 	spelling-phrase-check spelling-helper-test
 
@@ -21,13 +21,19 @@ SPELLING_HELPER_PYTEST = PYTHONPATH=scripts $(UV_ENV) $(UV) run --no-project \
 	--python 3.14 --with pathspec==$(PATHSPEC_VERSION) --with pytest==9.0.2 \
 	--with pytest-cov==7.0.0 python -m pytest
 
-all: check-fmt typecheck lint test spelling
+all: check-fmt typecheck docs-check lint test spelling
 
 check-fmt:
 	bun node_modules/@biomejs/biome/bin/biome check --linter-enabled=false --assist-enabled=false .
 
 typecheck:
 	bun run check:types
+
+# Zero-tolerance documentation gate: TypeDoc's notDocumented validation over
+# the shared, frontend, backend, and app/cli/lib surfaces (typedoc.*.json).
+# Emits no documentation artefacts.
+docs-check:
+	bun run docs:check
 
 lint:
 	bun run lint

--- a/app/auto-updater-linux.ts
+++ b/app/auto-updater-linux.ts
@@ -47,6 +47,7 @@ class AutoUpdater extends EventEmitter implements Electron.AutoUpdater {
   }
 }
 
+/** Shared auto-updater instance used on Linux, where Electron's built-in updater is unavailable. */
 const autoUpdaterLinux = new AutoUpdater();
 
 export default autoUpdaterLinux;

--- a/app/config.ts
+++ b/app/config.ts
@@ -14,6 +14,7 @@ const watchers: Function[] = [];
 let cfg: parsedConfig = {} as any;
 let _watcher: chokidar.FSWatcher;
 
+/** Lists deprecated CSS selectors still present in a configuration's `css`/`termCSS`. */
 export const getDeprecatedCSS = (config: configOptions) => {
   const deprecated: string[] = [];
   const deprecatedCSS = ['x-screen', 'x-row', 'cursor-node', '::selection'];
@@ -69,6 +70,7 @@ const _watch = () => {
   });
 };
 
+/** Registers a callback to run whenever the on-disk configuration is reloaded. */
 export const subscribe = (fn: Function) => {
   watchers.push(fn);
   return () => {
@@ -76,24 +78,29 @@ export const subscribe = (fn: Function) => {
   };
 };
 
+/** Returns the directory holding the user's configuration, for plugins to resolve paths against. */
 export const getConfigDir = () => {
   // expose config directory to load plugin from the right place
   return cfgDir;
 };
 
+/** Resolves the profile name to use when none is specified, falling back to the first profile. */
 export const getDefaultProfile = () => {
   return cfg.config.defaultProfile || cfg.config.profiles[0]?.name || 'default';
 };
 
 // get config for the default profile, keeping it for backward compatibility
+/** Returns the resolved configuration for the default profile. */
 export const getConfig = () => {
   return getProfileConfig(getDefaultProfile());
 };
 
+/** Returns the list of configured profiles. */
 export const getProfiles = () => {
   return cfg.config.profiles;
 };
 
+/** Merges a named profile's overrides onto the base configuration. */
 export const getProfileConfig = (profileName: string): configOptions => {
   const {profiles, defaultProfile, ...baseConfig} = cfg.config;
   const profileConfig = profiles.find((p) => p.name === profileName)?.config || {};
@@ -107,21 +114,30 @@ export const getProfileConfig = (profileName: string): configOptions => {
   return {...baseConfig, defaultProfile, profiles};
 };
 
+/** Opens the configuration file for editing in the user's preferred editor. */
 export const openConfig = () => {
   return _openConfig();
 };
 
-export const getPlugins = (): {plugins: string[]; localPlugins: string[]} => {
+/** Returns the configured plugin module names, split by npm-published vs. local plugins. */
+export const getPlugins = (): {
+  /** npm-published plugin module names. */
+  plugins: string[];
+  /** Locally developed plugin module names. */
+  localPlugins: string[];
+} => {
   return {
     plugins: cfg.plugins,
     localPlugins: cfg.localPlugins
   };
 };
 
+/** Returns the configured keymap overrides. */
 export const getKeymaps = () => {
   return cfg.keymaps;
 };
 
+/** Loads the configuration and starts watching it for changes. */
 export const setup = () => {
   cfg = _import();
   _watch();
@@ -130,6 +146,7 @@ export const setup = () => {
 
 export {get as getWin, recordState as winRecord, defaults as windowDefaults} from './config/windows';
 
+/** Fills in default colours on a plugin-decorated config so xterm CSS always has values to use. */
 export const fixConfigDefaults = (decoratedConfig: configOptions) => {
   const defaultConfig = getDefaultConfig().config!;
   const colorOverrides = getColorMap(decoratedConfig.colors);
@@ -138,6 +155,7 @@ export const fixConfigDefaults = (decoratedConfig: configOptions) => {
   return decoratedConfig;
 };
 
+/** Rewrites legacy hterm CSS selectors in a config to their xterm.js equivalents. */
 export const htermConfigTranslate = (config: configOptions) => {
   const cssReplacements: Record<string, string> = {
     'x-screen x-row([ {.[])': '.xterm-rows > div$1',

--- a/app/config/import.ts
+++ b/app/config/import.ts
@@ -15,16 +15,26 @@ type LoadedConfig = {
 
 type ConfigInit = (userCfg: rawConfig, defaultCfg: rawConfig) => parsedConfig;
 
+/** Filesystem locations that config import needs, injected so tests can substitute fakes. */
 export type ConfigImportPaths = {
+  /** Directory holding the user's configuration files. */
   cfgDir: string;
+  /** Path to the user's configuration file. */
   cfgPath: string;
+  /** Path to the bundled default configuration template. */
   defaultCfg: string;
+  /** Resolves the path to the platform-specific default keymap file. */
   defaultPlatformKeyPath: () => string;
+  /** Plugin directory layout used when seeding the config. */
   plugs: {
+    /** Directory for npm-installed plugins. */
     base: string;
+    /** Directory for locally developed plugins. */
     local: string;
   };
+  /** Filename of the bundled JSON schema for editor validation. */
   schemaFile: string;
+  /** Path to the bundled JSON schema source file. */
   schemaPath: string;
 };
 
@@ -337,6 +347,7 @@ export const createConfigImportModule = (dependencies: ConfigImportDependencies)
     return {userCfg, defaultCfg: _defaultCfg};
   };
 
+  /** Imports and validates the user and default configuration, ready for use. */
   const _import = () => {
     const imported = _importConf();
     defaultConfig = imported.defaultCfg;
@@ -411,5 +422,7 @@ const configImportModule = createConfigImportModule({
   paths: lazyPaths
 });
 
+/** Imports and validates the user and default configuration, ready for use. */
 export const _import = configImportModule._import;
+/** Returns the cached default config payload, importing it first if needed. */
 export const getDefaultConfig = configImportModule.getDefaultConfig;

--- a/app/config/init.ts
+++ b/app/config/init.ts
@@ -4,7 +4,7 @@ import type {parsedConfig, rawConfig, configOptions} from '@shared/types/config'
 import notify from '../notify';
 import mapKeys from '../utils/map-keys';
 
-// init config
+/** Merges the user's raw config onto the default config, filling in required profile fields. */
 const _init = (userCfg: rawConfig, defaultCfg: rawConfig): parsedConfig => {
   return {
     config: (() => {

--- a/app/config/json5-config.ts
+++ b/app/config/json5-config.ts
@@ -3,10 +3,25 @@ import JSON5 from 'json5';
 
 import type {configValidationDiagnostic, rawConfig} from '@shared/types/config';
 
-export type ParseSuccess<T> = {success: true; data: T};
-export type ParseFailure = {success: false; error: Error};
+/** A successful schema parse, carrying the validated data. */
+export type ParseSuccess<T> = {
+  /** Discriminant confirming the parse succeeded. */
+  success: true;
+  /** The validated value. */
+  data: T;
+};
+/** A failed schema parse, carrying the validation error. */
+export type ParseFailure = {
+  /** Discriminant confirming the parse failed. */
+  success: false;
+  /** The validation error, optionally carrying a structured diagnostic. */
+  error: Error;
+};
+/** The outcome of validating a value against a {@link ParseSchema}. */
 export type ParseResult<T> = ParseSuccess<T> | ParseFailure;
+/** A minimal schema contract, satisfied by both hand-rolled validators and Zod schemas. */
 export type ParseSchema<T> = {
+  /** Validates `value`, returning a discriminated success/failure result. */
   readonly safeParse: (value: unknown) => ParseResult<T>;
 };
 
@@ -20,18 +35,29 @@ type ParseDiagnosticContext = {
 type SchemaDiagnosticContext = Pick<ParseDiagnosticContext, 'itemType' | 'diagnosticHints'>;
 type ErrorMessageContext = Pick<ParseDiagnosticContext, 'source' | 'itemType'>;
 
+/** Inputs for parsing and validating a raw JSON5 document against a schema. */
 export interface ParseOptions<T> {
+  /** The raw JSON5 text to parse. */
   readonly raw: string;
+  /** A human-readable identifier for the source, used in diagnostics. */
   readonly source: string;
+  /** The schema to validate the parsed value against. */
   readonly schema: ParseSchema<T>;
+  /** The value to use when parsing or validation fails. */
   readonly fallback: T;
+  /** A label for the kind of item being parsed, used in diagnostic messages. */
   readonly itemType?: string;
+  /** Per-path hints merged into diagnostics to help users fix invalid config. */
   readonly diagnosticHints?: DiagnosticHints;
 }
 
+/** The result of parsing with diagnostics, always returning a usable value. */
 export type ParseWithDiagnosticsResult<T> = {
+  /** The parsed value, or `fallback` when parsing/validation failed. */
   value: T;
+  /** Diagnostics describing why the fallback was used, if it was. */
   diagnostics: configValidationDiagnostic[];
+  /** Whether `value` is the fallback rather than a successfully parsed result. */
   usedFallback: boolean;
 };
 
@@ -47,12 +73,15 @@ const createDiagnosticError = (diagnostic: configValidationDiagnostic): Diagnost
 
 const getPathForField = (field: string): string => `/${field}`;
 
+/** Narrows a value to a plain object (excluding arrays and `null`). */
 export const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
 
+/** Narrows a value to an array whose every element is a string. */
 export const isStringArray = (value: unknown): value is string[] =>
   Array.isArray(value) && value.every((item) => typeof item === 'string');
 
+/** Narrows a value to a keymap record: string or string-array bindings per command. */
 export const isKeymapConfig = (value: unknown): value is Record<string, string | string[]> =>
   isRecord(value) && Object.values(value).every((entry) => typeof entry === 'string' || isStringArray(entry));
 
@@ -91,6 +120,7 @@ const validateKeymapField: FieldValidator = makeFieldValidator(
   (field) => `Set \`${field}\` entries to keybinding strings or string arrays.`
 );
 
+/** Validates that a parsed payload has the expected top-level raw-config shape. */
 export const validateRawConfig = (value: unknown): ParseResult<Record<string, unknown>> => {
   if (!isRecord(value)) {
     return {
@@ -120,6 +150,7 @@ export const validateRawConfig = (value: unknown): ParseResult<Record<string, un
   return {success: true, data: value};
 };
 
+/** Validates a parsed payload and casts it to the raw config type on success. */
 export const safeParseRawConfig = (value: unknown): ParseResult<rawConfig> => {
   const parsed = validateRawConfig(value);
   if (!parsed.success) {
@@ -249,6 +280,7 @@ const toParseDiagnostic = (error: unknown, context: ParseDiagnosticContext): con
   );
 };
 
+/** Parses JSON5 text against a schema, returning a fallback value plus diagnostics on failure. */
 export const parseJson5WithSchemaDiagnostics = <T>(options: ParseOptions<T>): ParseWithDiagnosticsResult<T> => {
   const {raw, source, schema, fallback, itemType = 'config', diagnosticHints} = options;
   try {
@@ -271,6 +303,7 @@ export const parseJson5WithSchemaDiagnostics = <T>(options: ParseOptions<T>): Pa
   }
 };
 
+/** Parses JSON5 text against a schema, logging a warning and returning the fallback on failure. */
 export const parseJson5WithSchema = <T>(options: ParseOptions<T>): T => {
   const {source, itemType = 'config'} = options;
   const result = parseJson5WithSchemaDiagnostics(options);
@@ -284,6 +317,7 @@ export const parseJson5WithSchema = <T>(options: ParseOptions<T>): T => {
   return result.value;
 };
 
+/** Recursively sorts object keys so serialized output is deterministic. */
 export const sortKeys = (value: unknown): unknown => {
   if (Array.isArray(value)) {
     return value.map((item) => sortKeys(item));
@@ -300,4 +334,5 @@ export const sortKeys = (value: unknown): unknown => {
   return value;
 };
 
+/** Serializes a value as pretty-printed JSON5 with keys sorted for stable diffs. */
 export const stringifyJson5 = (value: unknown): string => `${JSON5.stringify(sortKeys(value), null, 2)}\n`;

--- a/app/config/open.ts
+++ b/app/config/open.ts
@@ -63,6 +63,7 @@ const openNotepad = (file: string) =>
     });
   });
 
+/** Opens the config file in the user's default editor, falling back to notepad on Windows. */
 const openConfig = () => {
   // If the user has no default editor for .json5 files, fallback to notepad.
   if (process.platform === 'win32') {

--- a/app/config/paths.ts
+++ b/app/config/paths.ts
@@ -13,27 +13,36 @@ import {app} from 'electron';
 
 import isDev from 'electron-is-dev';
 
+/** Filename of the current-format config file, relative to `cfgDir`. */
 const cfgFile = 'config.json5';
 const legacyCfgFile = 'hyper.json';
 const defaultCfgFile = 'config-default.json';
+/** Filename of the bundled JSON schema, relative to `cfgDir`. */
 const schemaFile = 'schema.json';
+/** The current user's home directory. */
 const homeDirectory = homedir();
 
-// If the user defines XDG_CONFIG_HOME they definitely want their config there,
-// otherwise use the home directory in linux/mac and userdata in windows
+/**
+ * Directory holding the user's configuration; may be reassigned below for legacy or
+ * dev overrides. If the user defines XDG_CONFIG_HOME they definitely want their
+ * config there, otherwise use the home directory on Linux/macOS and userdata on Windows.
+ */
 let cfgDir = process.env.XDG_CONFIG_HOME
   ? join(process.env.XDG_CONFIG_HOME, 'Hyper')
   : process.platform === 'win32'
     ? app.getPath('userData')
     : join(homeDirectory, '.config', 'Hyper');
 
+/** Path to the user's config file; may be reassigned below for legacy or dev overrides. */
 let cfgPath = join(cfgDir, cfgFile);
 const legacyCfgPath = join(cfgDir, legacyCfgFile);
+/** Path to the bundled JSON schema source file. */
 const schemaPath = resolve(__dirname, schemaFile);
 
 const devDir = resolve(__dirname, '../..');
 const devCfg = join(devDir, cfgFile);
 const devLegacyCfg = join(devDir, legacyCfgFile);
+/** Path to the bundled default configuration template. */
 const defaultCfg = resolve(__dirname, defaultCfgFile);
 
 const fileExists = (path: string): boolean => {
@@ -65,9 +74,13 @@ if (isDev) {
 }
 
 const plugins = resolve(cfgDir, 'plugins');
+/** Plugin storage locations, relative to the config directory. */
 const plugs = {
+  /** Directory for npm-installed plugins. */
   base: plugins,
+  /** Directory for locally developed plugins. */
   local: resolve(plugins, 'local'),
+  /** Directory for cached plugin installs. */
   cache: resolve(plugins, 'cache')
 };
 /** The Bun executable name for the current platform. */
@@ -93,9 +106,12 @@ const bun = (() => {
     return bunExecutable;
   }
 })();
+/** Path to the bundled `hyper` CLI launcher script. */
 const cliScriptPath = resolve(__dirname, '../../bin/hyper');
+/** Path where the `hyper` CLI symlink is installed on Linux/macOS. */
 const cliLinkPath = '/usr/local/bin/hyper';
 
+/** Path to the application icon used outside of packaged builds. */
 const icon = resolve(__dirname, '../static/icon96x96.png');
 
 const keymapPath = resolve(__dirname, '../keymaps');
@@ -103,6 +119,7 @@ const darwinKeys = join(keymapPath, 'darwin.json');
 const win32Keys = join(keymapPath, 'win32.json');
 const linuxKeys = join(keymapPath, 'linux.json');
 
+/** Resolves the bundled default keymap file for the current platform. */
 const defaultPlatformKeyPath = () => {
   switch (process.platform) {
     case 'darwin':

--- a/app/config/reload-handler.ts
+++ b/app/config/reload-handler.ts
@@ -241,7 +241,12 @@ export const partitionChanges = (diagnostics: ConfigReloadDiagnostic[]) => {
     }
   }
 
-  return {liveChanges, restartChanges};
+  return {
+    /** Changes that can be applied without restarting the application. */
+    liveChanges,
+    /** Changes that require an application restart to take effect. */
+    restartChanges
+  };
 };
 
 /**

--- a/app/config/windows.ts
+++ b/app/config/windows.ts
@@ -2,19 +2,29 @@ import type {BrowserWindow} from 'electron';
 
 import Config from 'electron-store';
 
+/** Fallback window position and size used before any state has been persisted. */
 export const defaults = {
+  /** Default top-left window position, in screen pixels. */
   windowPosition: [50, 50] as [number, number],
+  /** Default window size, in pixels. */
   windowSize: [540, 380] as [number, number]
 };
 
 // local storage
 const cfg = new Config({defaults});
 
+/** Reads the persisted window position and size, falling back to the defaults. */
 export function get() {
   const position = cfg.get('windowPosition', defaults.windowPosition);
   const size = cfg.get('windowSize', defaults.windowSize);
-  return {position, size};
+  return {
+    /** The window's top-left position, in screen pixels. */
+    position,
+    /** The window's size, in pixels. */
+    size
+  };
 }
+/** Persists the given window's current position and size for next launch. */
 export function recordState(win: BrowserWindow) {
   cfg.set('windowPosition', win.getPosition());
   cfg.set('windowSize', win.getSize());

--- a/app/menus/menu.ts
+++ b/app/menus/menu.ts
@@ -40,6 +40,7 @@ const formatLatencySummary = (metrics: RuntimeLatencyMetrics) => {
   )}ms, last ${metrics.lastMs.toFixed(2)}ms (n=${metrics.sampleCount})`;
 };
 
+/** Assembles the full application menu template from the per-section menu builders. */
 export const createMenu = (getLoadedPluginVersions: () => {name: string; version: string}[]) => {
   const config = getConfig();
   // We take only first shortcut in array for each command
@@ -123,6 +124,7 @@ export const createMenu = (getLoadedPluginVersions: () => {name: string; version
   return menu;
 };
 
+/** Builds and caches the application menu from a template, returning it for `Menu.setApplicationMenu`. */
 export const buildMenu = (template: Electron.MenuItemConstructorOptions[]): Electron.Menu => {
   menu_ = Menu.buildFromTemplate(template);
   return menu_;

--- a/app/menus/menus/darwin.ts
+++ b/app/menus/menus/darwin.ts
@@ -4,6 +4,7 @@ import {app} from 'electron';
 import type {BrowserWindow, MenuItemConstructorOptions} from 'electron';
 import type {CommandId} from '@shared/types/commands';
 
+/** Builds the macOS application menu (labelled with the app name), shown only on Darwin. */
 const darwinMenu = (
   commandKeys: Record<string, string>,
   execCommand: (command: CommandId, focusedWindow?: BrowserWindow) => void,

--- a/app/menus/menus/edit.ts
+++ b/app/menus/menus/edit.ts
@@ -6,6 +6,7 @@ import {makeMenuCommandExecutor, type MenuCommandRunner} from './utils';
 
 const asCommandId = (command: string): CommandId => command as CommandId;
 
+/** Builds the Edit menu template, with clipboard, caret movement, and buffer commands. */
 const editMenu = (commandKeys: Record<string, string>, execCommand: MenuCommandRunner) => {
   const execWithBrowserWindow = makeMenuCommandExecutor(execCommand);
 
@@ -147,7 +148,9 @@ const editMenu = (commandKeys: Record<string, string>, execCommand: MenuCommandR
   }
 
   return {
+    /** The menu bar label for this menu. */
     label: 'Edit',
+    /** The Edit menu's items, in display order. */
     submenu
   };
 };

--- a/app/menus/menus/help.ts
+++ b/app/menus/menus/help.ts
@@ -9,6 +9,7 @@ import {version} from '../../package.json';
 
 const {arch, env, platform, versions} = process;
 
+/** Builds the Help menu template, including the pre-filled GitHub issue report link. */
 const helpMenu = (_commands: Record<string, string>, showAbout: () => void): MenuItemConstructorOptions => {
   const submenu: MenuItemConstructorOptions[] = [
     {

--- a/app/menus/menus/shell.ts
+++ b/app/menus/menus/shell.ts
@@ -6,6 +6,7 @@ import {makeMenuCommandExecutor, type MenuCommandRunner} from './utils';
 
 const asCommandId = (command: string): CommandId => command as CommandId;
 
+/** Builds the Shell/File menu template, including per-profile tab and pane submenus. */
 const shellMenu = (
   commandKeys: Record<string, string>,
   execCommand: MenuCommandRunner,

--- a/app/menus/menus/tools.ts
+++ b/app/menus/menus/tools.ts
@@ -1,6 +1,7 @@
 import type {BrowserWindow, MenuItemConstructorOptions} from 'electron';
 import type {CommandId} from '@shared/types/commands';
 
+/** Builds the Tools menu template, including Windows-only system context menu commands. */
 const toolsMenu = (
   commands: Record<string, string>,
   execCommand: (command: CommandId, focusedWindow?: BrowserWindow) => void

--- a/app/menus/menus/utils.ts
+++ b/app/menus/menus/utils.ts
@@ -2,13 +2,16 @@
 import {BrowserWindow} from 'electron';
 import type {CommandId} from '@shared/types/commands';
 
+/** Signature of the app's command executor, as passed to menu builders. */
 export type MenuCommandRunner = (command: CommandId, focusedWindow?: BrowserWindow) => void;
 
+/** Narrows an Electron click handler's `focusedWindow` argument to a real `BrowserWindow`. */
 export const toBrowserWindow = (focusedWindow?: unknown): BrowserWindow | undefined =>
   focusedWindow instanceof BrowserWindow ? focusedWindow : undefined;
 
 const asCommandId = (command: string | CommandId): CommandId => command as CommandId;
 
+/** Wraps a command runner so menu `click` handlers can pass loosely typed arguments safely. */
 export const makeMenuCommandExecutor = (execCommand: MenuCommandRunner) => {
   return (command: CommandId, focusedWindow?: unknown) => {
     execCommand(asCommandId(command), toBrowserWindow(focusedWindow));

--- a/app/menus/menus/view.ts
+++ b/app/menus/menus/view.ts
@@ -6,6 +6,7 @@ import {makeMenuCommandExecutor, type MenuCommandRunner} from './utils';
 
 const asCommandId = (command: string): CommandId => command as CommandId;
 
+/** Builds the View menu template for reload, dev tools, and zoom commands. */
 const viewMenu = (commandKeys: Record<string, string>, execCommand: MenuCommandRunner): MenuItemConstructorOptions => {
   const execWithBrowserWindow = makeMenuCommandExecutor(execCommand);
 

--- a/app/menus/menus/window.ts
+++ b/app/menus/menus/window.ts
@@ -6,6 +6,7 @@ import {makeMenuCommandExecutor, type MenuCommandRunner} from './utils';
 
 const asCommandId = (command: string): CommandId => command as CommandId;
 
+/** Builds the Window menu template for tab and pane navigation, with a jump-to-tab submenu. */
 const windowMenu = (
   commandKeys: Record<string, string>,
   execCommand: MenuCommandRunner

--- a/app/notifications.ts
+++ b/app/notifications.ts
@@ -7,6 +7,7 @@ import {version} from './package.json';
 
 const NEWS_URL = 'https://hyper-news.now.sh';
 
+/** Polls the Hyper news endpoint for a notification message and forwards it to the renderer. */
 export default function fetchNotifications(win: BrowserWindow) {
   const {rpc} = win;
   const retry = (err?: Error) => {

--- a/app/notify.ts
+++ b/app/notify.ts
@@ -2,6 +2,7 @@ import {app, Notification} from 'electron';
 
 import {icon} from './config/paths';
 
+/** Logs and shows a native OS notification, deferring until Electron is ready if needed. */
 export default function notify(title: string, body = '', details: {error?: any} = {}) {
   console.log(`[Notification] ${title}: ${body}`);
   if (details.error) {

--- a/app/plugins.ts
+++ b/app/plugins.ts
@@ -121,6 +121,7 @@ function checkDeprecatedExtendKeymaps() {
 
 let updating = false;
 
+/** Reinstalls plugins from `package.json`, then reloads and notifies watchers of the update. */
 function updatePlugins({force = false} = {}) {
   if (updating) {
     return notify('Plugin update in progress');
@@ -200,8 +201,14 @@ function clearCache() {
 
 export {updatePlugins};
 
+/** Returns the name and version of every currently loaded plugin, for the About dialog. */
 export const getLoadedPluginVersions = () => {
-  return modules.map((mod) => ({name: mod._name, version: mod._version}));
+  return modules.map((mod) => ({
+    /** The plugin's module directory name. */
+    name: mod._name,
+    /** The plugin's `package.json` version, or `undefined` when it could not be read. */
+    version: mod._version
+  }));
 };
 
 // we schedule the initial plugins update
@@ -272,6 +279,7 @@ function toDependencies(plugins_: {plugins: string[]}) {
   return obj;
 }
 
+/** Registers a callback to run whenever the loaded plugin set changes. */
 export const subscribe = (fn: Function) => {
   watchers.push(fn);
   return () => {
@@ -279,11 +287,14 @@ export const subscribe = (fn: Function) => {
   };
 };
 
+/** Resolves the on-disk paths of every configured plugin, npm-installed and local. */
 function getPaths() {
   return {
+    /** Resolved paths of npm-installed plugins. */
     plugins: plugins.plugins.map((name) => {
       return resolve(path, 'node_modules', name.split('#')[0]);
     }),
+    /** Resolved paths of locally developed plugins. */
     localPlugins: plugins.localPlugins.map((name) => {
       return resolve(localPath, name);
     })
@@ -293,9 +304,14 @@ function getPaths() {
 // expose to renderer
 export {getPaths};
 
-// get paths from renderer
+/** Returns the base directories plugins and local plugins are installed under. */
 export const getBasePaths = () => {
-  return {path, localPath};
+  return {
+    /** Directory holding npm-installed plugins. */
+    path,
+    /** Directory holding locally developed plugins. */
+    localPath
+  };
 };
 
 function requirePlugins(): any[] {
@@ -335,6 +351,7 @@ function requirePlugins(): any[] {
   return [...plugins_, ...localPlugins].map(load).filter((v): v is Record<string, any> => Boolean(v));
 }
 
+/** Invokes each loaded plugin's `onApp` hook, reporting per-plugin errors without aborting. */
 export const onApp = (app_: App) => {
   modules.forEach((plugin) => {
     if (plugin.onApp) {
@@ -349,6 +366,7 @@ export const onApp = (app_: App) => {
   });
 };
 
+/** Invokes each loaded plugin's `onWindowClass` hook, reporting per-plugin errors without aborting. */
 export const onWindowClass = (win: BrowserWindow) => {
   modules.forEach((plugin) => {
     if (plugin.onWindowClass) {
@@ -363,6 +381,7 @@ export const onWindowClass = (win: BrowserWindow) => {
   });
 };
 
+/** Invokes each loaded plugin's `onWindow` hook, reporting per-plugin errors without aborting. */
 export const onWindow = (win: BrowserWindow) => {
   modules.forEach((plugin) => {
     if (plugin.onWindow) {
@@ -409,8 +428,15 @@ function decorateClass(base: any, key: string) {
   return decorateEntity(base, key, 'function');
 }
 
+/** Collects deprecated CSS selectors introduced by each plugin's decorated config, by plugin name. */
 export const getDeprecatedConfig = () => {
-  const deprecated: Record<string, {css: string[]}> = {};
+  const deprecated: Record<
+    string,
+    {
+      /** Deprecated CSS selectors this plugin's decorated config still uses. */
+      css: string[];
+    }
+  > = {};
   const baseConfig = config.getConfig();
   modules.forEach((plugin) => {
     if (!plugin.decorateConfig) {
@@ -435,14 +461,17 @@ export const getDeprecatedConfig = () => {
   return deprecated;
 };
 
+/** Applies each plugin's `decorateMenu` hook to the application menu template. */
 export const decorateMenu = (tpl: MenuItemConstructorOptions[]) => {
   return decorateObject(tpl, 'decorateMenu');
 };
 
+/** Applies each plugin's `decorateEnv` hook to the base shell environment. */
 export const getDecoratedEnv = (baseEnv: Record<string, string>) => {
   return decorateObject(baseEnv, 'decorateEnv');
 };
 
+/** Resolves a profile's config, decorated by plugins and normalized for the terminal. */
 export const getDecoratedConfig = (profile: string) => {
   ensureRuntimeDefaultsPersisted();
   const baseConfig = config.getProfileConfig(profile);
@@ -452,6 +481,7 @@ export const getDecoratedConfig = (profile: string) => {
   return translatedConfig;
 };
 
+/** Resolves keymaps merged from config, runtime plugin contributions, and plugin decoration. */
 export const getDecoratedKeymaps = () => {
   ensureRuntimeDefaultsPersisted();
   const baseKeymaps = config.getKeymaps();
@@ -462,27 +492,33 @@ export const getDecoratedKeymaps = () => {
   return decoratedKeymaps;
 };
 
+/** Returns command definitions contributed by runtime plugins. */
 export const getRuntimePluginCommands = () => {
   ensureRuntimeDefaultsPersisted();
   return getRuntimePluginCommandDefinitions(config.getConfig());
 };
 
+/** Applies each plugin's `decorateBrowserOptions` hook to the window's Electron options. */
 export const getDecoratedBrowserOptions = <T>(defaults: T): T => {
   return decorateObject(defaults, 'decorateBrowserOptions');
 };
 
+/** Applies each plugin's `decorateWindowClass` hook to the window class. */
 export const decorateWindowClass = <T>(defaults: T): T => {
   return decorateObject(defaults, 'decorateWindowClass');
 };
 
+/** Applies each plugin's `decorateSessionOptions` hook to the pty session options. */
 export const decorateSessionOptions = <T>(defaults: T): T => {
   return decorateObject(defaults, 'decorateSessionOptions');
 };
 
+/** Applies each plugin's `decorateSessionClass` hook to the session class. */
 export const decorateSessionClass = <T>(Session: T): T => {
   return decorateClass(Session, 'decorateSessionClass');
 };
 
+/** Converts a plugin list into an npm dependencies map, keyed by package name. */
 export {toDependencies as _toDependencies};
 
 const ipcMain = _ipcMain as IpcMainWithCommands;

--- a/app/plugins/extensions.ts
+++ b/app/plugins/extensions.ts
@@ -1,3 +1,8 @@
+/**
+ * Plugin API hook names that Hyper recognizes when decorating and extending the app.
+ *
+ * @internal
+ */
 export const availableExtensions = new Set([
   'onApp',
   'onWindowClass',

--- a/app/rpc.ts
+++ b/app/rpc.ts
@@ -10,9 +10,13 @@ import type {FilterNever, MainEvents, RendererEvents, TypedEmitter} from '@share
 
 /** Main-process RPC server that routes renderer events over IPC. */
 export class Server {
+  /** Internal event bus used to dispatch events received from the renderer. */
   emitter: TypedEmitter<MainEvents>;
+  /** Whether `destroy` has already run and this server should no longer register listeners. */
   destroyed = false;
+  /** The window this RPC server is bound to. */
   win: BrowserWindow;
+  /** Unique per-window channel id used for IPC message routing. */
   id!: string;
 
   constructor(win: BrowserWindow) {
@@ -50,6 +54,7 @@ export class Server {
     }
   }
 
+  /** The bound window's web contents, for sending/observing renderer IPC. */
   get wc() {
     return this.win.webContents;
   }
@@ -62,19 +67,23 @@ export class Server {
     return this.emitter.emit(ev as FilterNever<MainEvents>, data as MainEvents[FilterNever<MainEvents>]);
   }
 
+  /** IPC handler registered on `this.id`, forwarding renderer events onto `emitter`. */
   ipcListener = <U extends keyof MainEvents>(_event: IpcMainEvent, {ev, data}: {ev: U; data?: MainEvents[U]}) =>
     this.emitMainEvent(ev, data);
 
+  /** Subscribes to a renderer-originated event. */
   on = <U extends keyof MainEvents>(ev: U, fn: (arg0: MainEvents[U]) => void) => {
     this.emitter.on(ev, fn);
     return this;
   };
 
+  /** Subscribes to a renderer-originated event for a single occurrence. */
   once = <U extends keyof MainEvents>(ev: U, fn: (arg0: MainEvents[U]) => void) => {
     this.emitter.once(ev, fn);
     return this;
   };
 
+  /** Sends an event to the renderer, returning false if the window has been destroyed. */
   emit<U extends Exclude<keyof RendererEvents, FilterNever<RendererEvents>>>(ch: U): boolean;
   emit<U extends FilterNever<RendererEvents>>(ch: U, data: RendererEvents[U]): boolean;
   emit<U extends keyof RendererEvents>(ch: U, data?: RendererEvents[U]) {
@@ -87,6 +96,7 @@ export class Server {
     return false;
   }
 
+  /** Tears down IPC listeners for this server, or marks it destroyed if not yet registered. */
   destroy() {
     this.emitter.removeAllListeners();
     this.wc.removeAllListeners();
@@ -99,6 +109,7 @@ export class Server {
   }
 }
 
+/** Creates an RPC server bound to a browser window's renderer process. */
 const createRPC = (win: BrowserWindow) => {
   return new Server(win);
 };

--- a/app/runtime/golden-path-demo.ts
+++ b/app/runtime/golden-path-demo.ts
@@ -10,8 +10,11 @@ export const GOLDEN_PATH_KEYBINDING = 'ctrl+alt+shift+g';
 
 /** Settings payload persisted under `config.plugins[pluginId]`. */
 export type GoldenPathPluginSettings = {
+  /** Whether runtime command and keybinding contributions are active. */
   readonly enabled: boolean;
+  /** Notification text emitted when the plugin command is invoked. */
   readonly message: string;
+  /** Prefix rendered by the tab decoration provider for each tab title. */
   readonly tabPrefix: string;
 };
 
@@ -22,7 +25,11 @@ export const goldenPathSettingsDefaults: GoldenPathPluginSettings = {
   tabPrefix: 'GP'
 };
 
-/** JSON-schema-compatible settings descriptor used by the plugin manifest. */
+/**
+ * JSON-schema-compatible settings descriptor used by the plugin manifest.
+ *
+ * @internal
+ */
 export const goldenPathSettingsSchema = {
   type: 'object',
   additionalProperties: false,
@@ -59,38 +66,59 @@ export const goldenPathCommandDefinition: CommandDefinition = {
 
 /** Shared tab decoration shape returned by runtime plugin providers. */
 export type RuntimeTabDecorationBadge = {
+  /** Short badge text shown alongside the tab title. */
   readonly text?: string;
+  /** Icon identifier rendered for the badge. */
   readonly icon?: string;
+  /** Tooltip text shown on hover. */
   readonly tooltip?: string;
+  /** Visual severity used to style the badge. */
   readonly kind?: 'info' | 'warn' | 'error';
 };
 
+/** An actionable icon rendered on a tab, invoking a command when clicked. */
 export type RuntimeTabDecorationWidget = {
+  /** Icon identifier rendered for the widget. */
   readonly icon: string;
+  /** Command invoked when the widget is activated. */
   readonly command: CommandId;
+  /** Tooltip text shown on hover. */
   readonly tooltip?: string;
 };
 
+/** Decoration applied to a single tab by a {@link RuntimeTabDecorationProvider}. */
 export type RuntimeTabDecoration = {
+  /** Replacement title for the tab, when provided. */
   readonly title?: string;
+  /** Secondary text shown beneath the tab title, when provided. */
   readonly subtitle?: string;
+  /** Status badges rendered on the tab. */
   readonly badges?: readonly RuntimeTabDecorationBadge[];
+  /** Actionable widgets rendered on the tab. */
   readonly widgets?: readonly RuntimeTabDecorationWidget[];
 };
 
 /** Context passed to runtime tab decoration providers. */
 export type RuntimeTabDecorationContext = {
+  /** Stable identifier of the tab being decorated. */
   readonly tabId: string;
+  /** Zero-based position of the tab within its window. */
   readonly tabIndex: number;
+  /** Whether this tab is the currently focused tab. */
   readonly active: boolean;
+  /** Whether the tab's shell has produced output since it was last viewed. */
   readonly hasActivity: boolean;
+  /** The tab's current title, when set. */
   readonly title?: string;
 };
 
 /** Runtime tab decoration provider contribution contract. */
 export type RuntimeTabDecorationProvider = {
+  /** Stable identifier used to order and deduplicate providers. */
   readonly id: string;
+  /** Higher-priority providers are applied first when decorations conflict. */
   readonly priority: number;
+  /** Computes a tab's decoration, or returns nothing to leave it undecorated. */
   readonly provideDecoration: (
     context: RuntimeTabDecorationContext,
     settings: Record<string, unknown>
@@ -99,14 +127,23 @@ export type RuntimeTabDecorationProvider = {
 
 /** Runtime plugin manifest contract for roadmap 1.3.1 contributions. */
 export type RuntimePluginManifest = {
+  /** Stable, namespaced plugin identifier. */
   readonly id: string;
+  /** Plugin version string. */
   readonly version: string;
+  /** Human-readable plugin name shown in the UI. */
   readonly displayName: string;
+  /** Human-readable description of what the plugin does. */
   readonly description: string;
+  /** JSON-schema-compatible descriptor for the plugin's settings. */
   readonly settingsSchema: Readonly<Record<string, unknown>>;
+  /** Default values for the plugin's settings. */
   readonly settingsDefaults: Readonly<Record<string, unknown>>;
+  /** Commands the plugin registers with the runtime. */
   readonly commands: readonly CommandDefinition[];
+  /** Default keybindings for the plugin's commands, keyed by command id. */
   readonly keybindings: Readonly<Record<string, readonly string[]>>;
+  /** Tab decoration providers the plugin contributes. */
   readonly tabDecorationProviders: readonly RuntimeTabDecorationProvider[];
 };
 

--- a/app/runtime/plugin-runtime-json5-parser.ts
+++ b/app/runtime/plugin-runtime-json5-parser.ts
@@ -32,7 +32,12 @@ import {
  * `openBraceIndex` points at the opening `{` character and `closeBraceIndex`
  * points at the matching closing `}` character.
  */
-export type Json5ObjectRange = {openBraceIndex: number; closeBraceIndex: number};
+export type Json5ObjectRange = {
+  /** Index of the opening `{` character. */
+  openBraceIndex: number;
+  /** Index of the matching closing `}` character. */
+  closeBraceIndex: number;
+};
 
 /**
  * Captures a parsed key/value entry inside a JSON5 object.
@@ -43,28 +48,40 @@ export type Json5ObjectRange = {openBraceIndex: number; closeBraceIndex: number}
  * `hasTrailingComma` is true when a comma follows the value before the next key.
  */
 export type Json5ObjectProperty = {
+  /** The parsed key name. */
   key: string;
+  /** Index of the first character of the key token. */
   keyStartIndex: number;
+  /** Index of the first non-whitespace/comment character of the value. */
   valueStartIndex: number;
+  /** Index of the terminating delimiter (`,` or `}` boundary) after the value. */
   valueEndIndex: number;
+  /** Whether a comma follows the value before the next key. */
   hasTrailingComma: boolean;
 };
 
 /** Read-only start/limit cursor window used for parser scans. */
 export type ParseRange = {
+  /** Inclusive index where the scan begins. */
   readonly startIndex: number;
+  /** Exclusive index where the scan must stop. */
   readonly limitIndex: number;
 };
 
 /** Read-only single cursor index wrapper used for parser helper calls. */
 export type IndexCursor = {
+  /** Current scan position within the source document. */
   readonly index: number;
 };
 
 /** Read-only key wrapper used for object-property lookups. */
 export type PropertyKey = {
+  /** The wrapped key string. */
   readonly value: string;
-} & {readonly __brand: 'PropertyKey'};
+} & {
+  /** Nominal-typing brand preventing accidental use of a plain string as a key. */
+  readonly __brand: 'PropertyKey';
+};
 
 /**
  * `propertyKey` constructs a `PropertyKey` from a raw key string.

--- a/app/runtime/plugin-runtime-json5-parsing-state.ts
+++ b/app/runtime/plugin-runtime-json5-parsing-state.ts
@@ -9,10 +9,15 @@
  * `depth` tracks nested object brace depth.
  */
 export type ParsingState = {
+  /** The active quote delimiter when inside a string, or `null` otherwise. */
   inString: '"' | "'" | null;
+  /** Whether the previous character was an escape (`\`). */
   isEscaped: boolean;
+  /** Whether the cursor is currently inside a `//` line comment. */
   inLineComment: boolean;
+  /** Whether the cursor is currently inside a block comment. */
   inBlockComment: boolean;
+  /** Nested object brace depth. */
   depth: number;
 };
 
@@ -42,7 +47,12 @@ export const processBlockComment = (
   state: ParsingState,
   current: string,
   next: string
-): {state: ParsingState; skipNext: boolean} =>
+): {
+  /** The (possibly updated) parser state. */
+  state: ParsingState;
+  /** Whether the caller should advance past the next character. */
+  skipNext: boolean;
+} =>
   current === '*' && next === '/'
     ? {state: {...state, inBlockComment: false}, skipNext: true}
     : {state, skipNext: false};

--- a/app/runtime/plugin-runtime-json5-roundtrip.ts
+++ b/app/runtime/plugin-runtime-json5-roundtrip.ts
@@ -9,31 +9,52 @@ import type {rawConfig} from '@shared/types/config';
 type RuntimePluginSettings = Record<string, unknown>;
 /** Represents a JSON5 object property key with validation semantics. */
 export type PropertyKey = {
+  /** The wrapped key string. */
   readonly value: string;
-} & {readonly __brand: 'PropertyKey'};
+} & {
+  /** Nominal-typing brand preventing accidental use of a plain string as a key. */
+  readonly __brand: 'PropertyKey';
+};
 
 /** Represents a plugin identifier. */
 export type PluginId = {
+  /** The wrapped plugin id string. */
   readonly value: string;
-} & {readonly __brand: 'PluginId'};
+} & {
+  /** Nominal-typing brand preventing accidental use of a plain string as a plugin id. */
+  readonly __brand: 'PluginId';
+};
 
 /** Represents a path through nested JSON5 objects. */
 export type PropertyPath = {
+  /** The path's property keys, from outermost to innermost. */
   readonly segments: readonly PropertyKey[];
-} & {readonly __brand: 'PropertyPath'};
+} & {
+  /** Nominal-typing brand preventing accidental use of a plain array as a path. */
+  readonly __brand: 'PropertyPath';
+};
 
+/** Wraps a raw string as a validated {@link PropertyKey}. */
 export const propertyKey = (value: string): PropertyKey => ({value}) as PropertyKey;
+/** Wraps a raw string as a validated {@link PluginId}. */
 export const pluginId = (value: string): PluginId => ({value}) as PluginId;
+/** Wraps a sequence of key segments as a validated {@link PropertyPath}. */
 export const propertyPath = (segments: readonly PropertyKey[]): PropertyPath => ({segments}) as PropertyPath;
 /** Nominal type representing a raw JSON5 document string.
  *  Prevents confusing arbitrary strings with a document under round-trip. */
-export type Json5Document = string & {readonly __brand: 'Json5Document'};
+export type Json5Document = string & {
+  /** Nominal-typing brand preventing accidental use of a plain string as a document. */
+  readonly __brand: 'Json5Document';
+};
 
 /** Wraps a raw string as a Json5Document. No validation is performed. */
 export const json5Document = (raw: string): Json5Document => raw as Json5Document;
 
+/** A single plugin's settings to persist into the JSON5 config document. */
 export type PluginPersistencePatch = {
+  /** The plugin whose settings are being persisted. */
   pluginId: PluginId;
+  /** The settings values to write. */
   settings: RuntimePluginSettings;
 };
 
@@ -209,6 +230,7 @@ const applyPluginSettingsPatch = (doc: Json5Document, patch: PluginPersistencePa
   return upsertObjectProperty(nextDoc, pluginsRange, propertyKey(patch.pluginId.value), patch.settings);
 };
 
+/** Applies each plugin's settings patch to the document, preserving formatting and comments. */
 export const applyPluginSettingsPatches = (
   doc: Json5Document,
   patches: readonly PluginPersistencePatch[]
@@ -224,6 +246,7 @@ export const applyPluginSettingsPatches = (
   return nextDoc;
 };
 
+/** Parses and validates a JSON5 document as a raw config, returning `null` on failure. */
 export const parseConfigJson5Strict = (doc: Json5Document): rawConfig | null => {
   try {
     const parsed = JSON5.parse(doc) as unknown;

--- a/app/runtime/plugin-runtime.ts
+++ b/app/runtime/plugin-runtime.ts
@@ -19,8 +19,11 @@ import {runtimePluginManifests, type RuntimePluginManifest} from './golden-path-
 
 type RuntimePluginSettings = Record<string, unknown>;
 type RuntimePluginSettingsNamespace = Record<string, RuntimePluginSettings>;
+/** A keyboard shortcut assigned to more than one command. */
 export type KeybindingConflict = {
+  /** The colliding shortcut string. */
   readonly keys: string;
+  /** The commands that all claim this shortcut. */
   readonly commands: readonly string[];
 };
 type ReadTextFile = (path: string, encoding: BufferEncoding) => string;

--- a/app/session.ts
+++ b/app/session.ts
@@ -91,12 +91,19 @@ interface SessionOptions {
   shellArgs?: string[];
   profile: string;
 }
+/** A terminal session backed by a pty, batching output for efficient IPC delivery. */
 export default class Session extends EventEmitter {
+  /** The underlying pty process, or `null` before `init` has spawned one. */
   pty: IPty | null;
+  /** Batches pty output for efficient delivery to the renderer. */
   batcher: DataBatcher | null;
+  /** The shell executable path currently in use. */
   shell: string | null;
+  /** Whether the session has already emitted `exit` and should not do so again. */
   ended: boolean;
+  /** Timestamp (ms) the session was constructed, used to detect early shell exit. */
   initTimestamp: number;
+  /** Name of the profile this session was created from. */
   profile!: string;
   constructor(options: SessionOptions) {
     super();
@@ -108,6 +115,7 @@ export default class Session extends EventEmitter {
     this.init(options);
   }
 
+  /** Spawns the pty and wires up data/exit handling, retrying with a fallback shell on early exit. */
   init({uid, rows, cols, cwd, shell: _shell, shellArgs: _shellArgs, profile}: SessionOptions) {
     this.profile = profile;
     const envFromConfig = config.getProfileConfig(profile).env || {};
@@ -218,10 +226,12 @@ No fallback available, please check the shell config.
     this.shell = shell;
   }
 
+  /** Ends the session by destroying the underlying pty. */
   exit() {
     this.destroy();
   }
 
+  /** Writes input to the pty, if one is running. */
   write(data: string) {
     if (this.pty) {
       this.pty.write(data);
@@ -230,6 +240,7 @@ No fallback available, please check the shell config.
     }
   }
 
+  /** Resizes the pty to match the terminal's current dimensions. */
   resize({cols, rows}: {cols: number; rows: number}) {
     if (this.pty) {
       try {
@@ -243,6 +254,7 @@ No fallback available, please check the shell config.
     }
   }
 
+  /** Kills the pty process and marks the session as ended. */
   destroy() {
     if (this.pty) {
       try {

--- a/app/ui/contextmenu.ts
+++ b/app/ui/contextmenu.ts
@@ -24,6 +24,7 @@ const filterCutCopy = (selection: string, menuItem: MenuItemConstructorOptions) 
   return menuItem;
 };
 
+/** Builds the terminal's right-click context menu, merging edit and shell menu items. */
 const contextMenuTemplate = (selection: string) => {
   const commandKeys = getCommandKeys(getDecoratedKeymaps());
   const _shell = shellMenu(

--- a/app/ui/window.ts
+++ b/app/ui/window.ts
@@ -160,6 +160,7 @@ const parseSessionExtraOptions = (payload: unknown): sessionExtraOptions => {
   return parsedOptions;
 };
 
+/** Creates and wires up a new application window, including its RPC channel and pty sessions. */
 export function newWindow(
   options_: BrowserWindowConstructorOptions,
   cfg: configOptions,

--- a/app/updater.ts
+++ b/app/updater.ts
@@ -92,7 +92,9 @@ interface ReleaseInfo {
  * Options for the updater function.
  */
 export interface UpdaterOptions {
+  /** Timer functions to use; overridable so tests can inject fakes. */
   scheduler?: SchedulerSeam;
+  /** Logger to use for error reporting; overridable so tests can inject fakes. */
   logger?: LoggerSeam;
 }
 
@@ -140,6 +142,7 @@ async function init(scheduler: SchedulerSeam, logger: LoggerSeam) {
   }
 }
 
+/** Initializes the auto-updater for a window and wires update-available/downloaded events. */
 const updater = (win: BrowserWindow, options?: UpdaterOptions) => {
   const scheduler = options?.scheduler ?? {
     setTimeout: globalThis.setTimeout,

--- a/app/utils/cli-install.ts
+++ b/app/utils/cli-install.ts
@@ -131,6 +131,7 @@ const logNotify = (withNotification: boolean, title: string, body: string, detai
   withNotification && notify(title, body, details);
 };
 
+/** Installs the `hyper` CLI command for the current platform (symlink or PATH entry). */
 export const installCLI = async (withNotification: boolean) => {
   if (process.platform === 'win32') {
     try {

--- a/app/utils/clock.ts
+++ b/app/utils/clock.ts
@@ -19,7 +19,6 @@
 /**
  * Semantic contract for wall-clock providers used by runtime telemetry.
  *
- * @export
  * @remarks
  * Implementations must return epoch milliseconds, remain deterministic under
  * test doubles, and avoid side effects.
@@ -40,7 +39,6 @@ export interface Clock {
 /**
  * Default wall-clock implementation backed by `Date.now()`.
  *
- * @export
  * @remarks
  * This default is intentionally simple and can be replaced in tests by mocking
  * the module or injecting an alternative `Clock`.

--- a/app/utils/colours.ts
+++ b/app/utils/colours.ts
@@ -19,6 +19,7 @@ const colorList = [
   'grayscale'
 ];
 
+/** Converts a positional colour array into a named palette map; passes non-arrays through unchanged. */
 export const getColorMap: <T>(colors: T) => T extends (infer U)[] ? {[k: string]: U} : T = (colors) => {
   if (!Array.isArray(colors)) {
     return colors;

--- a/app/utils/map-keys.ts
+++ b/app/utils/map-keys.ts
@@ -11,6 +11,7 @@ const generatePrefixedCommand = (command: string, shortcuts: string[]) => {
   return result;
 };
 
+/** Normalizes keymap shortcuts, migrating deprecated `cmd` bindings and expanding `:prefix` commands. */
 const mapKeys = (config: Record<string, string[] | string>) => {
   return Object.keys(config).reduce((keymap: Record<string, string[]>, command: string) => {
     if (!command) {

--- a/app/utils/renderer-utils.ts
+++ b/app/utils/renderer-utils.ts
@@ -23,6 +23,7 @@ const inputSendToWriteLatencyByUid: Record<string, RuntimeLatencyMetrics> = Obje
 const isWebGLRenderer = (type: RendererType | undefined): type is 'WebGL' => type === 'WebGL';
 const toKilobytes = (bytes: number) => Math.round((bytes / 1024) * 100) / 100;
 
+/** Returns a zeroed latency metrics accumulator. */
 const createRuntimeLatencyMetrics = (): RuntimeLatencyMetrics => ({
   sampleCount: 0,
   totalMs: 0,
@@ -30,29 +31,37 @@ const createRuntimeLatencyMetrics = (): RuntimeLatencyMetrics => ({
   lastMs: 0
 });
 
+/** Returns the current renderer type (e.g. WebGL, canvas) for each tracked renderer, by uid. */
 function getRendererTypes() {
   return rendererTypes;
 }
 
+/** Returns how many times each renderer fallback reason has been recorded. */
 function getRendererFallbackReasonCounts() {
   return rendererFallbackReasonCounts;
 }
 
+/** Returns the current and peak count of concurrently active WebGL renderer contexts. */
 function getRendererWebGLContextCounts() {
   return {
+    /** Number of WebGL renderer contexts currently active. */
     current: rendererWebGLContextCounts.current,
+    /** Highest number of concurrently active WebGL renderer contexts observed. */
     peak: rendererWebGLContextCounts.peak
   };
 }
 
+/** Returns the last-reported runtime metrics for each tracked renderer, by uid. */
 function getRendererRuntimeMetricsByUid() {
   return rendererRuntimeMetricsByUid;
 }
 
+/** Returns input-send-to-pty-write latency metrics for each tracked renderer, by uid. */
 function getInputSendToWriteLatencyByUid() {
   return inputSendToWriteLatencyByUid;
 }
 
+/** Aggregates per-renderer runtime metrics into a single summary, for the About dialog. */
 function getAggregatedRendererRuntimeMetrics() {
   const metricsByUid = Object.values(rendererRuntimeMetricsByUid);
   const aggregatedInputKeydownToSend = metricsByUid.reduce<RuntimeLatencyMetrics>(
@@ -75,11 +84,17 @@ function getAggregatedRendererRuntimeMetrics() {
       longFrameThresholdMs: Math.max(aggregate.longFrameThresholdMs, metrics.frameTiming.longFrameThresholdMs)
     }),
     {
+      /** Number of frame-timing samples aggregated. */
       sampleCount: 0,
+      /** Sum of all sampled frame durations, in milliseconds. */
       totalMs: 0,
+      /** Longest sampled frame duration, in milliseconds. */
       maxMs: 0,
+      /** Most recently sampled frame duration, in milliseconds. */
       lastMs: 0,
+      /** Number of frames that exceeded the long-frame threshold. */
       longFrameCount: 0,
+      /** Threshold, in milliseconds, above which a frame is considered long. */
       longFrameThresholdMs: LONG_FRAME_THRESHOLD_MS
     }
   );
@@ -94,13 +109,18 @@ function getAggregatedRendererRuntimeMetrics() {
   );
 
   return {
+    /** Aggregated keydown-to-send latency across all tracked renderers. */
     inputKeydownToSend: aggregatedInputKeydownToSend,
+    /** Aggregated frame-timing statistics across all tracked renderers. */
     frameTiming: aggregatedFrameTiming,
+    /** The most recent timestamp (ms) any tracked renderer reported metrics. */
     updatedAtMs: latestUpdateAtMs,
+    /** The longest reporting interval (ms) observed across tracked renderers. */
     reportIntervalMs
   };
 }
 
+/** Aggregates input-send-to-pty-write latency across all tracked renderers. */
 function getAggregatedInputSendToWriteLatencyMetrics() {
   return Object.values(inputSendToWriteLatencyByUid).reduce<RuntimeLatencyMetrics>(
     (aggregate, metrics) => ({
@@ -113,10 +133,12 @@ function getAggregatedInputSendToWriteLatencyMetrics() {
   );
 }
 
+/** Records the latest runtime metrics report for a renderer. */
 function setRendererRuntimeMetrics(uid: RendererUid, runtimeMetrics: RendererRuntimeMetrics) {
   rendererRuntimeMetricsByUid[uid] = runtimeMetrics;
 }
 
+/** Records a single input-send-to-pty-write latency sample for a renderer. */
 function recordInputSendToWriteLatency(uid: RendererUid, sampleMs: number) {
   if (!Number.isFinite(sampleMs)) {
     return;
@@ -131,6 +153,7 @@ function recordInputSendToWriteLatency(uid: RendererUid, sampleMs: number) {
   inputSendToWriteLatencyByUid[uid] = metrics;
 }
 
+/** Reports the active PTY batching thresholds, and whether they match the build's expected values. */
 function getPtyBatchingThresholdMetrics(runtimeThresholds?: {durationMs: number; maxBytes: number}) {
   const durationMs = runtimeThresholds?.durationMs ?? PTY_BATCH_DURATION_MS;
   const maxBytes = runtimeThresholds?.maxBytes ?? PTY_BATCH_MAX_BYTES;
@@ -140,13 +163,18 @@ function getPtyBatchingThresholdMetrics(runtimeThresholds?: {durationMs: number;
       : durationMs === PTY_BATCH_EXPECTED_DURATION_MS && maxBytes === PTY_BATCH_EXPECTED_MAX_BYTES;
 
   return {
+    /** Time window, in milliseconds, pty output is batched over before flushing. */
     durationMs,
+    /** Maximum bytes buffered before a batch is flushed early. */
     maxBytes,
+    /** `maxBytes` expressed in kilobytes, for display. */
     maxKilobytes: toKilobytes(maxBytes),
+    /** Whether these thresholds match the build's expected constants. */
     parity
   };
 }
 
+/** Tracks a renderer's active type, updating WebGL context counts and fallback reason tallies. */
 function setRendererType(
   uid: RendererUid,
   type: RendererType,
@@ -175,6 +203,7 @@ function setRendererType(
   rendererFallbackReasonCounts[reason] = (rendererFallbackReasonCounts[reason] ?? 0) + 1;
 }
 
+/** Clears tracking state for a renderer that has been unloaded, adjusting WebGL context counts. */
 function unsetRendererType(uid: RendererUid) {
   if (isWebGLRenderer(rendererTypes[uid])) {
     rendererWebGLContextCounts.current = Math.max(0, rendererWebGLContextCounts.current - 1);
@@ -185,6 +214,7 @@ function unsetRendererType(uid: RendererUid) {
   delete inputSendToWriteLatencyByUid[uid];
 }
 
+/** Clears all renderer tracking state; intended for tests. */
 function resetRendererTracking() {
   for (const uid of Object.keys(rendererTypes)) {
     delete rendererTypes[uid];

--- a/app/utils/shell-fallback.ts
+++ b/app/utils/shell-fallback.ts
@@ -1,10 +1,13 @@
+/** Suggests a fallback shell configuration to retry after an early shell exit, or `null` if none applies. */
 export const getFallBackShellConfig = (
   shell: string,
   shellArgs: string[],
   defaultShell: string,
   defaultShellArgs: string[]
 ): {
+  /** The shell executable to retry with. */
   shell: string;
+  /** Arguments to pass to the fallback shell. */
   shellArgs: string[];
 } | null => {
   if (shellArgs.length > 0) {

--- a/app/utils/system-context-menu.ts
+++ b/app/utils/system-context-menu.ts
@@ -31,6 +31,7 @@ function addValues(hyperKey: HKEY, commandKey: HKEY) {
   }
 }
 
+/** Registers "Open Hyper here" entries in the Windows Explorer right-click menu. */
 export const add = () => {
   regKeys.forEach((regKey) => {
     try {
@@ -49,6 +50,7 @@ export const add = () => {
   });
 };
 
+/** Removes the "Open Hyper here" entries from the Windows Explorer right-click menu. */
 export const remove = () => {
   regKeys.forEach((regKey) => {
     try {

--- a/app/utils/to-electron-background-colour.ts
+++ b/app/utils/to-electron-background-colour.ts
@@ -1,9 +1,10 @@
 // Packages
 import Color from 'color';
 
-// returns a background colour that's in hex
-// format including the alpha channel (e.g.: `#00000050`)
-// input can be any css value (rgb, hsl, string…)
+/**
+ * Converts any CSS colour value (rgb, hsl, string...) to Electron's hex-with-alpha
+ * background colour format (e.g. `#00000050`).
+ */
 const toElectronBackgroundColor = (bgColor: string) => {
   const color = Color(bgColor);
 

--- a/app/utils/window-utils.ts
+++ b/app/utils/window-utils.ts
@@ -1,5 +1,6 @@
 import electron from 'electron';
 
+/** Returns true when the given window position falls within any connected display's work area. */
 export function positionIsValid(position: [number, number]) {
   const displays = electron.screen.getAllDisplays();
   const [x, y] = position;

--- a/backend/tsconfig.typedoc.json
+++ b/backend/tsconfig.typedoc.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "incremental": true,
+    "noEmit": false,
+    "emitDeclarationOnly": false
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -86,6 +86,7 @@
         "postcss": "^8.5.8",
         "prettier": "^3.2.5",
         "tailwindcss": "^4.2.2",
+        "typedoc": "^0.28.20",
         "typescript": "^5.4.5",
       },
     },
@@ -301,6 +302,8 @@
 
     "@gar/promisify": ["@gar/promisify@1.1.3", "", {}, "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw=="],
 
+    "@gerrit0/mini-shiki": ["@gerrit0/mini-shiki@3.23.0", "", { "dependencies": { "@shikijs/engine-oniguruma": "^3.23.0", "@shikijs/langs": "^3.23.0", "@shikijs/themes": "^3.23.0", "@shikijs/types": "^3.23.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg=="],
+
     "@inquirer/ansi": ["@inquirer/ansi@2.0.3", "", {}, "sha512-g44zhR3NIKVs0zUesa4iMzExmZpLUdTLRMCStqX3GE5NT6VkPcxQGJ+uC8tDgBUC/vB1rUhUd55cOf++4NZcmw=="],
 
     "@inquirer/checkbox": ["@inquirer/checkbox@5.1.0", "", { "dependencies": { "@inquirer/ansi": "^2.0.3", "@inquirer/core": "^11.1.5", "@inquirer/figures": "^2.0.3", "@inquirer/type": "^4.0.3" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-/HjF1LN0a1h4/OFsbGKHNDtWICFU/dqXCdym719HFTyJo9IG7Otr+ziGWc9S0iQuohRZllh+WprSgd5UW5Fw0g=="],
@@ -411,6 +414,16 @@
 
     "@redux-devtools/extension": ["@redux-devtools/extension@3.3.0", "", { "dependencies": { "@babel/runtime": "^7.23.2", "immutable": "^4.3.4" } }, "sha512-X34S/rC8S/M1BIrkYD1mJ5f8vlH0BDqxXrs96cvxSBo4FhMdbhU+GUGsmNYov1xjSyLMHgo8NYrUG8bNX7525g=="],
 
+    "@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g=="],
+
+    "@shikijs/langs": ["@shikijs/langs@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0" } }, "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg=="],
+
+    "@shikijs/themes": ["@shikijs/themes@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0" } }, "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA=="],
+
+    "@shikijs/types": ["@shikijs/types@3.23.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ=="],
+
+    "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
+
     "@sindresorhus/is": ["@sindresorhus/is@5.3.0", "", {}, "sha512-CX6t4SYQ37lzxicAqsBtxA3OseeoVrh9cSJ5PFYam0GksYlupRfy1A+Q4aYD3zvcfECLc0zO2u+ZnR2UYKvCrw=="],
 
     "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
@@ -445,6 +458,8 @@
 
     "@types/fs-extra": ["@types/fs-extra@11.0.4", "", { "dependencies": { "@types/jsonfile": "*", "@types/node": "*" } }, "sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ=="],
 
+    "@types/hast": ["@types/hast@3.0.5", "", { "dependencies": { "@types/unist": "*" } }, "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g=="],
+
     "@types/http-cache-semantics": ["@types/http-cache-semantics@4.0.0", "", {}, "sha512-c3Xy026kOF7QOTn00hbIllV1dLR9hG9NkSrLQgCVs8NF6sBU+VGWjD3wLPhmh1TYAc7ugCFsvHYMN4VcBN1U1A=="],
 
     "@types/js-cookie": ["@types/js-cookie@2.2.7", "", {}, "sha512-aLkWa0C0vO5b4Sr798E26QgOkss68Un0bLjs7u9qxzPT5CG+8DuNTffWES58YzJs3hrVAOs1wonycqEBqNJubA=="],
@@ -474,6 +489,8 @@
     "@types/retry": ["@types/retry@0.12.0", "", {}, "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="],
 
     "@types/seamless-immutable": ["@types/seamless-immutable@7.1.19", "", {}, "sha512-EBUncfvAjFqmOTlhp095M9DruNViePvR6bUJzIymEOdyu33/ats/G3cLcqTzGRQceUWbLuJrXm9H73XYimLb/Q=="],
+
+    "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.6", "", {}, "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="],
 
@@ -997,6 +1014,8 @@
 
     "lilconfig": ["lilconfig@3.1.3", "", {}, "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="],
 
+    "linkify-it": ["linkify-it@5.0.2", "", { "dependencies": { "uc.micro": "^2.0.0" } }, "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q=="],
+
     "lodash": ["lodash@4.17.23", "", {}, "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="],
 
     "lodash.difference": ["lodash.difference@4.5.0", "", {}, "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw="],
@@ -1007,15 +1026,21 @@
 
     "lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
 
+    "lunr": ["lunr@2.3.9", "", {}, "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow=="],
+
     "make-error": ["make-error@1.3.6", "", {}, "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="],
 
     "make-fetch-happen": ["make-fetch-happen@13.0.1", "", { "dependencies": { "@npmcli/agent": "^2.0.0", "cacache": "^18.0.0", "http-cache-semantics": "^4.1.1", "is-lambda": "^1.0.1", "minipass": "^7.0.2", "minipass-fetch": "^3.0.0", "minipass-flush": "^1.0.5", "minipass-pipeline": "^1.2.4", "negotiator": "^0.6.3", "proc-log": "^4.2.0", "promise-retry": "^2.0.1", "ssri": "^10.0.0" } }, "sha512-cKTUFc/rbKUd/9meOvgrpJ2WrNzymt6jfRDdwg5UCnVzv9dTpEj9JS5m3wtziXVCjluIXyL8pcaukYqezIzZQA=="],
+
+    "markdown-it": ["markdown-it@14.3.0", "", { "dependencies": { "argparse": "^2.0.1", "entities": "^4.5.0", "linkify-it": "^5.0.2", "mdurl": "^2.0.0", "punycode.js": "^2.3.1", "uc.micro": "^2.1.0" }, "bin": { "markdown-it": "bin/markdown-it.mjs" } }, "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw=="],
 
     "matcher": ["matcher@3.0.0", "", { "dependencies": { "escape-string-regexp": "^4.0.0" } }, "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
     "mdn-data": ["mdn-data@2.0.14", "", {}, "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow=="],
+
+    "mdurl": ["mdurl@2.0.0", "", {}, "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w=="],
 
     "meow": ["meow@14.1.0", "", {}, "sha512-EDYo6VlmtnumlcBCbh1gLJ//9jvM/ndXHfVXIFrZVr6fGcwTUyCTFNTLCKuY3ffbK8L/+3Mzqnd58RojiZqHVw=="],
 
@@ -1235,6 +1260,8 @@
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
+    "punycode.js": ["punycode.js@2.3.1", "", {}, "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA=="],
+
     "quick-lru": ["quick-lru@5.1.1", "", {}, "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="],
 
     "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
@@ -1425,9 +1452,13 @@
 
     "type-fest": ["type-fest@0.13.1", "", {}, "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="],
 
+    "typedoc": ["typedoc@0.28.20", "", { "dependencies": { "@gerrit0/mini-shiki": "^3.23.0", "lunr": "^2.3.9", "markdown-it": "^14.3.0", "minimatch": "^10.2.5", "yaml": "^2.9.0" }, "peerDependencies": { "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x" }, "bin": { "typedoc": "bin/typedoc" } }, "sha512-uSKqkh8Cr48vllnEy+jdaAgOeR6Y+QCBW7usgUsKj7gJEfR7stw9U/fE49LBnj2tPRKPY0c0EBJSWe9Appmplg=="],
+
     "typescript": ["typescript@5.4.5", "", {}, "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ=="],
 
     "typescript-json-schema": ["typescript-json-schema@0.67.1", "", { "dependencies": { "@types/json-schema": "^7.0.9", "@types/node": "^18.11.9", "glob": "^7.1.7", "path-equal": "^1.2.5", "safe-stable-stringify": "^2.2.0", "ts-node": "^10.9.1", "typescript": "~5.5.0", "vm2": "^3.10.0", "yargs": "^17.1.1" }, "bin": { "typescript-json-schema": "bin/typescript-json-schema" } }, "sha512-vKTZB/RoYTIBdVP7E7vrgHMCssBuhja91wQy498QIVhvfRimaOgjc98uwAXmZ7mbLUytJmOSbF11wPz+ByQeXg=="],
+
+    "uc.micro": ["uc.micro@2.1.0", "", {}, "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="],
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
@@ -1501,7 +1532,7 @@
 
     "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
 
-    "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
     "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 
@@ -1720,6 +1751,8 @@
     "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "path-scurry/minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
+    "postcss-load-config/yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
 
     "postject/commander": ["commander@9.5.0", "", {}, "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ=="],
 

--- a/cli/api.ts
+++ b/cli/api.ts
@@ -86,6 +86,7 @@ type ConfigPathInput = {
  * Public CLI helper surface for inspecting and mutating Hyper plugin config.
  */
 export type CliApi = {
+  /** Resolved path to the Hyper config file this instance reads and writes. */
   readonly configPath: string;
   /** Returns `true` when the resolved config file exists on disk. */
   exists: () => boolean;

--- a/frontend/tsconfig.typedoc.json
+++ b/frontend/tsconfig.typedoc.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "incremental": true,
+    "noEmit": false,
+    "emitDeclarationOnly": false
+  }
+}

--- a/lib/actions/config.ts
+++ b/lib/actions/config.ts
@@ -2,6 +2,7 @@ import type {configOptions} from '@shared/types/config';
 import {CONFIG_LOAD, CONFIG_RELOAD} from '@shared/constants/config';
 import type {HyperActions} from '../../typings/hyper';
 
+/** Requests that the store load the given config as the current configuration. */
 export function loadConfig(config: configOptions): HyperActions {
   return {
     type: CONFIG_LOAD,
@@ -9,6 +10,7 @@ export function loadConfig(config: configOptions): HyperActions {
   };
 }
 
+/** Requests that the store replace the current configuration with a freshly reloaded one. */
 export function reloadConfig(config: configOptions): HyperActions {
   const now = Date.now();
   return {

--- a/lib/actions/header.ts
+++ b/lib/actions/header.ts
@@ -11,6 +11,7 @@ import {transport} from '../transport';
 
 import {userExitTermGroup, setActiveGroup} from './term-groups';
 
+/** Requests that the given tab be closed and its term group exited. */
 export function closeTab(uid: string) {
   return (dispatch: HyperDispatch) => {
     dispatch({
@@ -23,6 +24,7 @@ export function closeTab(uid: string) {
   };
 }
 
+/** Requests that the given tab become the active tab. */
 export function changeTab(uid: string) {
   return (dispatch: HyperDispatch) => {
     dispatch({
@@ -35,6 +37,7 @@ export function changeTab(uid: string) {
   };
 }
 
+/** Requests that the main process maximize the application window. */
 export function maximize() {
   return (dispatch: HyperDispatch) => {
     dispatch({
@@ -46,6 +49,7 @@ export function maximize() {
   };
 }
 
+/** Requests that the main process restore the window from its maximized state. */
 export function unmaximize() {
   return (dispatch: HyperDispatch) => {
     dispatch({
@@ -57,6 +61,7 @@ export function unmaximize() {
   };
 }
 
+/** Requests that the main process open the hamburger menu at the given screen coordinates. */
 export function openHamburgerMenu(coordinates: {x: number; y: number}) {
   return (dispatch: HyperDispatch) => {
     dispatch({
@@ -68,6 +73,7 @@ export function openHamburgerMenu(coordinates: {x: number; y: number}) {
   };
 }
 
+/** Requests that the main process minimize the application window. */
 export function minimize() {
   return (dispatch: HyperDispatch) => {
     dispatch({
@@ -79,6 +85,7 @@ export function minimize() {
   };
 }
 
+/** Requests that the main process close the application window. */
 export function close() {
   return (dispatch: HyperDispatch) => {
     dispatch({

--- a/lib/actions/index.ts
+++ b/lib/actions/index.ts
@@ -2,6 +2,7 @@ import {INIT} from '@shared/constants';
 import type {HyperDispatch} from '../../typings/hyper';
 import {transport} from '../transport';
 
+/** Requests initial startup dispatch and signals the main process that the renderer is ready. */
 export default function init() {
   return (dispatch: HyperDispatch) => {
     dispatch({

--- a/lib/actions/notifications.ts
+++ b/lib/actions/notifications.ts
@@ -2,6 +2,7 @@ import {NOTIFICATION_MESSAGE, NOTIFICATION_DISMISS} from '@shared/constants/noti
 import type {HyperActions} from '../../typings/hyper';
 import type {AddNotificationParams} from '../bootstrap/renderer-bootstrap';
 
+/** Requests removal of the notification identified by `id`. */
 export function dismissNotification(id: string): HyperActions {
   return {
     type: NOTIFICATION_DISMISS,
@@ -9,6 +10,7 @@ export function dismissNotification(id: string): HyperActions {
   };
 }
 
+/** Requests that a new notification message be shown to the user. */
 export function addNotificationMessage({text, url = null, dismissable = true}: AddNotificationParams): HyperActions {
   return {
     type: NOTIFICATION_MESSAGE,

--- a/lib/actions/term-groups.ts
+++ b/lib/actions/term-groups.ts
@@ -59,9 +59,12 @@ function requestSplit(direction: 'VERTICAL' | 'HORIZONTAL') {
     };
 }
 
+/** Requests a new session split vertically from the active (or specified) session. */
 export const requestVerticalSplit = requestSplit(DIRECTION.VERTICAL);
+/** Requests a new session split horizontally from the active (or specified) session. */
 export const requestHorizontalSplit = requestSplit(DIRECTION.HORIZONTAL);
 
+/** Requests that the given term group be resized to the provided pane size ratios. */
 export function resizeTermGroup(uid: string, sizes: number[]): HyperActions {
   return {
     uid: asTermGroupId(uid),
@@ -70,6 +73,7 @@ export function resizeTermGroup(uid: string, sizes: number[]): HyperActions {
   };
 }
 
+/** Requests a brand new tab (root term group) with a session in it. */
 export function requestTermGroup({activeUid: requestedActiveUid, profile: requestedProfile}: SplitRequestParams = {}) {
   return (dispatch: HyperDispatch, getState: () => HyperState) => {
     dispatch({
@@ -86,6 +90,7 @@ export function requestTermGroup({activeUid: requestedActiveUid, profile: reques
   };
 }
 
+/** Requests that the session belonging to the given term group become the active session. */
 export function setActiveGroup(uid: string) {
   return (dispatch: HyperDispatch, getState: () => HyperState) => {
     const {termGroups} = getState();
@@ -133,6 +138,7 @@ const findNextSessionUid = (state: ITermState, group: ITermGroup) => {
   return findFirstSession(state, state.termGroups[nextUid]);
 };
 
+/** Requests that the term group containing a PTY-terminated session be exited. */
 export function ptyExitTermGroup(sessionUid: string) {
   return (dispatch: HyperDispatch, getState: () => HyperState) => {
     const {termGroups} = getState();
@@ -158,6 +164,7 @@ export function ptyExitTermGroup(sessionUid: string) {
   };
 }
 
+/** Requests that the given term group and its sessions be closed by the user. */
 export function userExitTermGroup(uid: string) {
   return (dispatch: HyperDispatch, getState: () => HyperState) => {
     const {termGroups} = getState();
@@ -190,6 +197,7 @@ export function userExitTermGroup(uid: string) {
   };
 }
 
+/** Requests that the currently active term group be exited. */
 export function exitActiveTermGroup() {
   return (dispatch: HyperDispatch, getState: () => HyperState) => {
     dispatch({

--- a/lib/actions/ui.ts
+++ b/lib/actions/ui.ts
@@ -35,6 +35,7 @@ import {transport} from '../transport';
 import {requestSession, sendSessionData, setActiveSession} from './sessions';
 import {setActiveGroup} from './term-groups';
 
+/** Requests that the context menu for the given selection be shown, unless quick-edit is active. */
 export function openContextMenu(uid: string, selection: string) {
   return (dispatch: HyperDispatch, getState: () => HyperState) => {
     dispatch({
@@ -51,6 +52,7 @@ export function openContextMenu(uid: string, selection: string) {
   };
 }
 
+/** Requests that the terminal font size be increased by one point. */
 export function increaseFontSize() {
   return (dispatch: HyperDispatch, getState: () => HyperState) => {
     dispatch({
@@ -68,6 +70,7 @@ export function increaseFontSize() {
   };
 }
 
+/** Requests that the terminal font size be decreased by one point, floored to avoid xterm rendering issues. */
 export function decreaseFontSize() {
   return (dispatch: HyperDispatch, getState: () => HyperState) => {
     dispatch({
@@ -86,12 +89,14 @@ export function decreaseFontSize() {
   };
 }
 
+/** Requests that the terminal font size be reset to its configured default. */
 export function resetFontSize(): HyperActions {
   return {
     type: UI_FONT_SIZE_RESET
   };
 }
 
+/** Requests that font smoothing be recalculated for the current device pixel ratio. */
 export function setFontSmoothing() {
   return (dispatch: HyperDispatch) => {
     setTimeout(() => {
@@ -106,6 +111,7 @@ export function setFontSmoothing() {
   };
 }
 
+/** Requests that the store record the window's updated maximized state. */
 export function windowGeometryUpdated({isMaximized}: {isMaximized: boolean}): HyperActions {
   return {
     type: UI_WINDOW_GEOMETRY_CHANGED,
@@ -156,7 +162,9 @@ function moveToNeighbourPane(type: typeof UI_MOVE_NEXT_PANE | typeof UI_MOVE_PRE
   };
 }
 
+/** Requests that focus move to the next pane in the active tab. */
 export const moveToNextPane = moveToNeighbourPane(UI_MOVE_NEXT_PANE);
+/** Requests that focus move to the previous pane in the active tab. */
 export const moveToPreviousPane = moveToNeighbourPane(UI_MOVE_PREV_PANE);
 
 const getGroupUids = (state: HyperState) => {
@@ -164,6 +172,7 @@ const getGroupUids = (state: HyperState) => {
   return rootGroups.map(({uid}) => uid);
 };
 
+/** Requests that the active tab move one position to the left. */
 export function moveLeft() {
   return (dispatch: HyperDispatch, getState: () => HyperState) => {
     dispatch({
@@ -184,6 +193,7 @@ export function moveLeft() {
   };
 }
 
+/** Requests that the active tab move one position to the right. */
 export function moveRight() {
   return (dispatch: HyperDispatch, getState: () => HyperState) => {
     dispatch({
@@ -204,6 +214,7 @@ export function moveRight() {
   };
 }
 
+/** Requests that the tab at index `i` (or the last tab) become active. */
 export function moveTo(i: number | 'last') {
   return (dispatch: HyperDispatch, getState: () => HyperState) => {
     if (i === 'last') {
@@ -233,6 +244,7 @@ export function moveTo(i: number | 'last') {
   };
 }
 
+/** Requests that the window's moved position be recorded and font smoothing recalculated. */
 export function windowMove(window: any) {
   return (dispatch: HyperDispatch) => {
     dispatch({
@@ -245,6 +257,7 @@ export function windowMove(window: any) {
   };
 }
 
+/** Requests that font smoothing be recalculated after a window geometry change. */
 export function windowGeometryChange() {
   return (dispatch: HyperDispatch) => {
     dispatch({
@@ -256,6 +269,7 @@ export function windowGeometryChange() {
   };
 }
 
+/** Requests that the file at `path` be opened: run if executable, or `cd`'d into if a directory. */
 export function openFile(path: string) {
   return (dispatch: HyperDispatch) => {
     dispatch({
@@ -284,18 +298,21 @@ export function openFile(path: string) {
   };
 }
 
+/** Requests that the application window enter full-screen mode. */
 export function enterFullScreen(): HyperActions {
   return {
     type: UI_ENTER_FULLSCREEN
   };
 }
 
+/** Requests that the application window leave full-screen mode. */
 export function leaveFullScreen(): HyperActions {
   return {
     type: UI_LEAVE_FULLSCREEN
   };
 }
 
+/** Requests a new session that runs the SSH command derived from the parsed URL. */
 export function openSSH(parsedUrl: ReturnType<typeof parseUrl>) {
   return (dispatch: HyperDispatch) => {
     dispatch({
@@ -319,6 +336,7 @@ export function openSSH(parsedUrl: ReturnType<typeof parseUrl>) {
   };
 }
 
+/** Requests that the given registered command be executed, via its handler or the transport. */
 export function execCommand(
   command: CommandId,
   fn: ((e: unknown, dispatch: HyperDispatch) => void) | undefined,
@@ -326,8 +344,11 @@ export function execCommand(
 ) {
   return (dispatch: HyperDispatch) =>
     dispatch({
+      /** Redux action type dispatched when a registered command is executed. */
       type: UI_COMMAND_EXEC,
+      /** Identifier of the command being executed. */
       command,
+      /** Runs the command's handler if one was supplied, else emits it over the transport. */
       effect() {
         if (fn) {
           fn(e, dispatch);

--- a/lib/actions/updater.ts
+++ b/lib/actions/updater.ts
@@ -3,6 +3,7 @@ import type {HyperActions} from '../../typings/hyper';
 import type {UpdateAvailableParams} from '../bootstrap/renderer-bootstrap';
 import {transport} from '../transport';
 
+/** Requests that the main process quit and install the downloaded update. */
 export function installUpdate(): HyperActions {
   return {
     type: UPDATE_INSTALL,
@@ -12,6 +13,7 @@ export function installUpdate(): HyperActions {
   };
 }
 
+/** Requests that the store record details of a newly available update. */
 export function updateAvailable({releaseName, notes, releaseUrl, canInstall}: UpdateAvailableParams): HyperActions {
   return {
     type: UPDATE_AVAILABLE,

--- a/lib/bootstrap/renderer-bootstrap.ts
+++ b/lib/bootstrap/renderer-bootstrap.ts
@@ -5,13 +5,40 @@ import type {RendererCommandTransport} from '@shared/types/transport';
 import {z} from 'zod';
 import type {SplitRequestParams} from '../types/request-shapes';
 
-export type AddSessionDataParams = {uid: string; data: string};
-export type SendSessionDataParams = {uid: string | null; data: string; escaped?: boolean};
-export type AddNotificationParams = {text: string; url?: string | null; dismissable?: boolean};
+/** Parameters for appending incoming PTY output to a session's buffer. */
+export type AddSessionDataParams = {
+  /** Identifier of the session the data belongs to. */
+  uid: string;
+  /** Raw PTY output to append. */
+  data: string;
+};
+/** Parameters for sending input data to a session's PTY. */
+export type SendSessionDataParams = {
+  /** Identifier of the target session, or `null` to target the active session. */
+  uid: string | null;
+  /** Input to write to the PTY. */
+  data: string;
+  /** Whether `data` has already been escaped and should be sent verbatim. */
+  escaped?: boolean;
+};
+/** Parameters for showing a notification message to the user. */
+export type AddNotificationParams = {
+  /** Notification body text. */
+  text: string;
+  /** Optional link to open when the notification is clicked. */
+  url?: string | null;
+  /** Whether the user can dismiss the notification. */
+  dismissable?: boolean;
+};
+/** Parameters describing a newly available application update. */
 export type UpdateAvailableParams = {
+  /** Name of the release being offered. */
   releaseName: string;
+  /** Release notes describing the update. */
   notes: string;
+  /** URL of the release page. */
   releaseUrl: string;
+  /** Whether the update can be installed automatically. */
   canInstall: boolean;
 };
 
@@ -104,19 +131,32 @@ type WindowLike = WindowGlobalsLike &
     document: Document;
   };
 
+/** Injectable dependencies the renderer bootstrap needs, so tests can substitute fakes. */
 export type RendererBootstrapDependencies = {
+  /** Redux action creator modules dispatched by transport event handlers. */
   actions: BootstrapActionModules;
+  /** Config loader/subscriber used to hydrate and refresh renderer configuration. */
   config: ConfigModuleLike;
+  /** Creates the Redux store for the renderer. */
   configureStore: () => StoreLike;
+  /** Reads a file and resolves its contents as base64, for bell-sound hydration. */
   getBase64FileData: (path: string) => Promise<string | null>;
+  /** Mounts the React application against the given store. */
   mountApp: (store: StoreLike) => MountResult;
+  /** Host operating system platform, used to gate platform-specific zoom fixes. */
   platform: NodeJS.Platform;
+  /** Plugin subsystem module, reloaded on transport 'reload' events. */
   plugins: PluginModuleLike;
+  /** RPC client exposed as a window global for plugin and legacy access. */
   rpc: unknown;
+  /** Command transport used to receive events from the main process. */
   transport: RendererCommandTransport;
+  /** Electron webFrame, used to correct zoom factor on affected platforms. */
   webFrame?: {
+    /** Sets the renderer's zoom factor. */
     setZoomFactor: (zoomFactor: number) => void;
   };
+  /** Window-like object whose globals are populated with renderer singletons. */
   windowObject: WindowLike;
 };
 
@@ -412,13 +452,14 @@ export const exposeRendererGlobals = ({
   return restoreProperties;
 };
 
+/** True when the bell is configured to play a sound and a sound URL is set. */
+const isBellSoundEnabled = (config: configOptions): config is configOptions & {bellSoundURL: string} =>
+  typeof config.bell === 'string' && config.bell.toUpperCase() === 'SOUND' && Boolean(config.bellSoundURL);
+
 /**
  * Initializes config state and keeps bell-sound hydration aligned with later
  * config change events.
  */
-const isBellSoundEnabled = (config: configOptions): config is configOptions & {bellSoundURL: string} =>
-  typeof config.bell === 'string' && config.bell.toUpperCase() === 'SOUND' && Boolean(config.bellSoundURL);
-
 export const initializeRendererConfig = ({
   actions,
   config,
@@ -547,7 +588,7 @@ export const registerRendererTransportListeners = ({
   };
 };
 
-// Keep a concise alias for test helpers and bootstrap-focused imports.
+/** Concise alias of {@link registerRendererTransportListeners} for test helpers and bootstrap imports. */
 export const registerTransportListeners = registerRendererTransportListeners;
 
 /**

--- a/lib/command-registry.ts
+++ b/lib/command-registry.ts
@@ -13,6 +13,7 @@ import type {
 import {SESSION_SEARCH} from '@shared/constants/sessions';
 import Ajv, {type ErrorObject, type ValidateFunction} from 'ajv';
 
+/** A legacy-style command handler invoked with the triggering event and the dispatch function. */
 export type CommandHandler = (event: unknown, dispatch: HyperDispatch) => void;
 
 interface RegisteredCommand extends CommandDefinition {
@@ -47,6 +48,7 @@ const createLegacyDefinition = (id: CommandId): CommandDefinition => ({
   }
 });
 
+/** Requests that the active (or given) session's search be closed, deferring to the terminal if none is open. */
 export const closeSearchAction = (uid?: string, keyEvent?: {catched?: boolean}) => {
   return (dispatch: HyperDispatch, getState: () => HyperState) => {
     const targetUid = uid ?? getState().sessions.activeUid;
@@ -111,6 +113,7 @@ const serializeAjvErrors = (errors: ErrorObject[] | null | undefined): CommandVa
     };
   });
 
+/** Builds an isolated command registry module, wiring in legacy search-close and focus dependencies. */
 export const createCommandRegistryModule = (dependencies: CommandRegistryDependencies) => {
   const ajv = new Ajv({allErrors: true});
   const validatorsByCommandId = new Map<CommandId, ValidateFunction>();
@@ -301,30 +304,55 @@ export const createCommandRegistryModule = (dependencies: CommandRegistryDepende
   };
 
   return {
+    /** Public `CommandRegistry<CommandHandler>` view exposing the core CRUD and validation API. */
     commandRegistry,
+    /** Alias of {@link register} for legacy call sites. */
     createCommand,
+    /** Alias of {@link remove} for legacy call sites. */
     deleteCommand,
+    /** Alias of {@link list} for legacy call sites. */
     enumerateCommands,
+    /** Looks up a command definition by id, returning a clone. */
     get,
+    /** Alias of {@link get} for legacy call sites. */
     getCommand,
+    /** Alias of {@link get} for legacy call sites. */
     getCommandDefinition,
+    /** Returns the handler registered for a command id, if any. */
     getCommandHandler,
+    /** Syncs runtime plugin commands and resolves the current shortcut-to-action keymap. */
     getRegisteredKeys,
+    /** Reports whether a command id is registered. */
     has,
+    /** Alias of {@link has} for legacy call sites. */
     hasCommand,
+    /** Alias of {@link has} for legacy call sites. */
     hasCommandDefinition,
+    /** Lists all registered command definitions, sorted by id. */
     list,
+    /** Alias of {@link list} for legacy call sites. */
     listCommands,
+    /** Adds or replaces a command definition, clearing any cached validator. */
     register,
+    /** Alias of {@link register} for legacy call sites. */
     registerCommand,
+    /** Bulk-registers legacy `{commandId: handler}` maps as handlers on existing/legacy definitions. */
     registerCommandHandlers,
+    /** Removes a command definition and its cached validator. */
     remove,
+    /** Alias of {@link remove} for legacy call sites. */
     removeCommand,
+    /** Alias of {@link register} for legacy call sites. */
     replaceCommand,
+    /** Alias of {@link register} for legacy call sites. */
     update,
+    /** Alias of {@link register} for legacy call sites. */
     updateCommand,
+    /** Validates command arguments against the command's compiled JSON schema. */
     validateArgs,
+    /** Alias of {@link validateArgs} for legacy call sites. */
     validateCommandArgs,
+    /** Alias of {@link validateArgs} for legacy call sites. */
     validateCommandArgsFor
   };
 };
@@ -346,29 +374,65 @@ const commandRegistryModule = createCommandRegistryModule({
 });
 
 /** Core CRUD and validation API. */
-export const {validateArgs, register, update, remove, get, list, has} = commandRegistryModule;
+export const {
+  /** Validates command arguments against the command's compiled JSON schema. */
+  validateArgs,
+  /** Adds or replaces a command definition, clearing any cached validator. */
+  register,
+  /** Alias of {@link register} for legacy call sites. */
+  update,
+  /** Removes a command definition and its cached validator. */
+  remove,
+  /** Looks up a command definition by id, returning a clone. */
+  get,
+  /** Lists all registered command definitions, sorted by id. */
+  list,
+  /** Reports whether a command id is registered. */
+  has
+} = commandRegistryModule;
 
 /** Public `CommandRegistry<CommandHandler>` entry point with CRUD and validation APIs. */
 export const commandRegistry: CommandRegistry<CommandHandler> = commandRegistryModule.commandRegistry;
 
 /** Async key resolution, handler management, and bulk registration. */
-export const {getRegisteredKeys, registerCommandHandlers, getCommandHandler} = commandRegistryModule;
+export const {
+  /** Syncs runtime plugin commands and resolves the current shortcut-to-action keymap. */
+  getRegisteredKeys,
+  /** Bulk-registers legacy `{commandId: handler}` maps as handlers on existing/legacy definitions. */
+  registerCommandHandlers,
+  /** Returns the handler registered for a command id, if any. */
+  getCommandHandler
+} = commandRegistryModule;
 
 /** Compat aliases — retained for call sites that use legacy command-verb naming. */
 export const {
+  /** Alias of {@link register} for legacy call sites. */
   registerCommand,
+  /** Alias of {@link register} for legacy call sites. */
   createCommand,
+  /** Alias of {@link register} for legacy call sites. */
   updateCommand,
+  /** Alias of {@link register} for legacy call sites. */
   replaceCommand,
+  /** Alias of {@link remove} for legacy call sites. */
   removeCommand,
+  /** Alias of {@link remove} for legacy call sites. */
   deleteCommand,
+  /** Alias of {@link get} for legacy call sites. */
   getCommand,
+  /** Alias of {@link get} for legacy call sites. */
   getCommandDefinition,
+  /** Alias of {@link list} for legacy call sites. */
   listCommands,
+  /** Alias of {@link list} for legacy call sites. */
   enumerateCommands,
+  /** Alias of {@link has} for legacy call sites. */
   hasCommand,
+  /** Alias of {@link has} for legacy call sites. */
   hasCommandDefinition,
+  /** Alias of {@link validateArgs} for legacy call sites. */
   validateCommandArgs,
+  /** Alias of {@link validateArgs} for legacy call sites. */
   validateCommandArgsFor
 } = commandRegistryModule;
 
@@ -387,4 +451,5 @@ const roleCommands = [
   'window:toggleFullScreen'
 ];
 
+/** Reports whether a command should be intercepted rather than left to reach Electron's menu roles. */
 export const shouldPreventDefault = (command: string) => !roleCommands.includes(command);

--- a/lib/components/header.tsx
+++ b/lib/components/header.tsx
@@ -19,6 +19,11 @@ type WindowControlButton = {
   className: string;
 };
 
+/**
+ * Window header chrome: hamburger menu, window controls, and the tab strip.
+ * Also owns the click-vs-drag disambiguation used when the header doubles as
+ * the window's draggable title bar.
+ */
 const Header = forwardRef(function Header(props: HeaderProps, ref: React.ForwardedRef<HTMLElement>) {
   const [headerMouseDownWindowX, setHeaderMouseDownWindowX] = useState<number>(0);
   const [headerMouseDownWindowY, setHeaderMouseDownWindowY] = useState<number>(0);

--- a/lib/components/new-tab.tsx
+++ b/lib/components/new-tab.tsx
@@ -73,6 +73,10 @@ function isFocusWithinDropdown(target: EventTarget | null, container: Node | nul
   return target !== null && 'nodeType' in target && (container?.contains(target as Node) ?? false);
 }
 
+/**
+ * New-tab trigger button that opens a profile dropdown; selecting a profile
+ * opens a tab with that profile and clicking away or `Escape` closes it.
+ */
 const DropdownButton = ({defaultProfile, profiles, openNewTab, backgroundColor, borderColor, tabsVisible}: Props) => {
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const ref = useRef<HTMLDivElement | null>(null);

--- a/lib/components/notification.tsx
+++ b/lib/components/notification.tsx
@@ -102,6 +102,10 @@ const useNotification = (props: NotificationProps, ref: React.ForwardedRef<HTMLD
   };
 };
 
+/**
+ * Notification bar item that fades out and auto-dismisses after
+ * `dismissAfter` ms, or immediately on user click when `userDismissable`.
+ */
 const Notification = forwardRef(function Notification(
   props: React.PropsWithChildren<NotificationProps>,
   ref: React.ForwardedRef<HTMLDivElement>

--- a/lib/components/notifications.tsx
+++ b/lib/components/notifications.tsx
@@ -10,6 +10,10 @@ import * as styles from './notifications.module.css';
 
 const Notification = decorate(Notification_, 'Notification');
 
+/**
+ * Stacks the font-size, resize, update, and message notifications above the
+ * terminal, showing only the ones flagged visible in the connected props.
+ */
 const Notifications = forwardRef(function Notifications(
   props: NotificationsProps,
   ref: React.ForwardedRef<HTMLDivElement>

--- a/lib/components/searchBox.tsx
+++ b/lib/components/searchBox.tsx
@@ -134,6 +134,10 @@ const SearchNavigation = ({
   </div>
 );
 
+/**
+ * Find-in-terminal bar: search input, case/whole-word/regex toggles, match
+ * count, and prev/next/close navigation, all driven by the connected props.
+ */
 const SearchBox = forwardRef(function SearchBox(props: SearchBoxProps, ref: React.ForwardedRef<HTMLDivElement>) {
   const {
     caseSensitive,

--- a/lib/components/split-pane.tsx
+++ b/lib/components/split-pane.tsx
@@ -70,6 +70,11 @@ function computeKeyResizeTarget(
   return action ? action(isVertical, currentSize, pairTotal) : null;
 }
 
+/**
+ * Lays out sibling term panes with draggable, keyboard-resizable dividers,
+ * emitting new pane sizes via `onResize` while keeping the pair's combined
+ * size constant.
+ */
 const SplitPane = forwardRef(function SplitPane(props: SplitPaneProps, ref: React.ForwardedRef<HTMLDivElement>) {
   const dragPanePosition = useRef<number>(0);
   const dragOffset = useRef<number>(0);

--- a/lib/components/tab.tsx
+++ b/lib/components/tab.tsx
@@ -50,6 +50,10 @@ const onTabMouseUp = (event: React.MouseEvent, onClose: () => void): void => {
   }
 };
 
+/**
+ * Single tab strip entry: selects on left click, closes on middle click or
+ * the close button, and reflects active/first/activity state in its styling.
+ */
 const Tab = forwardRef(function Tab(props: TabProps, ref: React.ForwardedRef<HTMLLIElement>) {
   const {isActive, isFirst, borderColor, hasActivity} = props;
 

--- a/lib/components/tabs.tsx
+++ b/lib/components/tabs.tsx
@@ -47,6 +47,11 @@ const TabItem = ({tab, index, totalTabs, borderColor, onChange, onClose, parentP
   return <Tab {...tabProps} />;
 };
 
+/**
+ * Tab strip that lists open tabs (hidden on non-mac when only one tab is
+ * open), re-renders on plugin tab-decoration updates, and hosts the
+ * new-tab dropdown.
+ */
 const Tabs = forwardRef(function Tabs(props: TabsProps, ref: React.ForwardedRef<HTMLElement>) {
   const [, forceDecorationRender] = useReducer((version: number) => version + 1, 0);
   const {tabs = [], borderColor, onChange, onClose, fullScreen} = props;

--- a/lib/components/term-group.tsx
+++ b/lib/components/term-group.tsx
@@ -153,10 +153,15 @@ const mapDispatchToProps = (dispatch: HyperDispatch, ownProps: TermGroupOwnProps
   }
 });
 
+/**
+ * Term-group node: renders a single terminal for a leaf group, or splits
+ * into `SplitPane`-arranged child groups for a branch group.
+ */
 const TermGroup = connect(mapStateToProps, mapDispatchToProps, null, {forwardRef: true})(TermGroup_);
 
 const DecoratedTermGroup = decorate(TermGroup, 'TermGroup');
 
 export default TermGroup;
 
+/** Props supplied to a term group by `connect`: its child groups and resize dispatch binding. */
 export type TermGroupConnectedProps = ReturnType<typeof mapStateToProps> & ReturnType<typeof mapDispatchToProps>;

--- a/lib/components/term.tsx
+++ b/lib/components/term.tsx
@@ -212,11 +212,17 @@ const getTermOptions = (props: TermProps): ITerminalOptions => {
 };
 
 const createRuntimeFrameTimingMetrics = () => ({
+  /** Number of animation frames sampled since the metrics were last reported. */
   sampleCount: 0,
+  /** Sum of sampled frame durations, in milliseconds. */
   totalMs: 0,
+  /** Longest sampled frame duration, in milliseconds. */
   maxMs: 0,
+  /** Duration of the most recently sampled frame, in milliseconds. */
   lastMs: 0,
+  /** Count of frames whose duration exceeded `longFrameThresholdMs`. */
   longFrameCount: 0,
+  /** Frame duration, in milliseconds, above which a frame counts as "long". */
   longFrameThresholdMs: LONG_FRAME_THRESHOLD_MS
 });
 
@@ -224,57 +230,103 @@ const createRuntimeFrameTimingMetrics = () => ({
 export default class Term extends React.PureComponent<
   TermProps,
   {
+    /** Options applied to the next find-in-terminal search. */
     searchOptions: {
+      /** Whether the find-in-terminal search matches letter case exactly. */
       caseSensitive: boolean;
+      /** Whether the find-in-terminal search matches whole words only. */
       wholeWord: boolean;
+      /** Whether the find-in-terminal search term is treated as a regular expression. */
       regex: boolean;
     };
+    /** Result summary of the most recent search; undefined until a search runs. */
     searchResults:
       | {
+          /** Index of the currently focused search match, for the "n of m" label. */
           resultIndex: number;
+          /** Total number of search matches found for the current term. */
           resultCount: number;
         }
       | undefined;
   }
 > {
+  /** DOM node that hosts the xterm instance; kept across mounts so terms survive pane moves. */
   termRef: HTMLElement | null;
+  /** Wrapper element observed for resize so the terminal can be re-fitted and re-visibility-checked. */
   termWrapperRef: HTMLElement | null;
+  /** Last xterm options applied, used to diff and apply only changed options on update. */
   termOptions: ITerminalOptions;
+  /** Disposables for xterm event listeners, torn down on unmount. */
   disposableListeners: IDisposable[];
+  /** Built-in bell sound played when no custom `bellSound` prop is set. */
   defaultBellSound: HTMLAudioElement | null;
+  /** Bell sound actually played on terminal bell events, or `null` when the bell is disabled. */
   bellSound: HTMLAudioElement | null;
+  /** Keeps the terminal sized to its container. */
   fitAddon: FitAddon;
+  /** Powers find-in-terminal search and match highlighting. */
   searchAddon: SearchAddon;
+  /** Canvas-based renderer addon, used as the WebGL fallback. */
   canvasAddon: CanvasAddon | null;
+  /** WebGL renderer addon, used when supported and not in cooldown after failures. */
   webglAddon: WebglAddon | null;
+  /** Ligature-rendering addon, active only alongside the canvas renderer. */
   ligaturesAddon: LigaturesAddon | null;
+  /** Renderer type last reported per terminal uid, shown in the main process's About dialog. */
   static rendererTypes: Record<RendererUid, RendererType> = {};
+  /** Underlying xterm.js terminal instance. */
   term!: Terminal;
+  /** Observes the wrapper element to trigger a debounced fit/visibility sync on resize. */
   resizeObserver?: ResizeObserver;
+  /** Debounce timer for the resize observer's fit/visibility sync. */
   resizeTimeout?: NodeJS.Timeout;
+  /** Pending animation frame for the debounced renderer visibility sync, or `null` when idle. */
   visibilityFrame: number | null;
+  /** Ensures the transparent-background WebGL warning is only logged once. */
   hasWarnedAboutTransparentWebGL: boolean;
+  /** Ensures the unsupported-WebGL2 warning is only logged once. */
   hasWarnedAboutUnsupportedWebGL: boolean;
+  /** Count of consecutive WebGL failures, used to decide when to back off retrying. */
   webglFailureCount: number;
+  /** Timestamp of the most recent WebGL failure, used to compute retry cooldowns. */
   webglLastFailureAt: number;
+  /** Minimum delay before retrying the WebGL renderer after a failure. */
   webglCooldownMs: number;
+  /** Failure count above which WebGL retries back off using `webglFailureDecayMs`. */
   webglFailureThreshold: number;
+  /** Time after which accumulated WebGL failures are forgotten. */
   webglFailureDecayMs: number;
+  /** Handle for the scheduled deterministic renderer retry, or `null` when none is pending. */
   webglRetryTimer: number | NodeJS.Timeout | null;
+  /** Handle for the active frame-timing `requestAnimationFrame` loop, or `null` when stopped. */
   frameTimingRaf: TimeMs | null;
+  /** Timestamp of the previous tracked animation frame, used to compute frame duration. */
   lastFrameTimestamp: TimeMs | null;
+  /** Recent keydown timestamps, used to attribute input-latency samples to keystrokes. */
   keydownTimestamps: TimeMs[];
+  /** Set when runtime metrics have changed since they were last reported to the main process. */
   hasUnreportedRuntimeMetrics: boolean;
+  /** Timestamp of the last runtime metrics report, used to throttle reporting frequency. */
   lastRuntimeMetricsReportAt: TimeMs;
+  /** Rolling keydown-to-input-send latency metrics reported for renderer diagnostics. */
   runtimeInputLatencyMetrics: ReturnType<typeof createRuntimeLatencyMetrics>;
+  /** Rolling animation-frame timing metrics reported for renderer diagnostics. */
   runtimeFrameTimingMetrics: ReturnType<typeof createRuntimeFrameTimingMetrics>;
+  /** Colours used to highlight active and inactive search matches. */
   searchDecorations: ISearchDecorationOptions;
+  /** Local component state backing the find-in-terminal search UI. */
   state = {
+    /** Options applied to the next find-in-terminal search. */
     searchOptions: {
+      /** Whether the find-in-terminal search matches letter case exactly. */
       caseSensitive: false,
+      /** Whether the find-in-terminal search matches whole words only. */
       wholeWord: false,
+      /** Whether the find-in-terminal search term is treated as a regular expression. */
       regex: false
     },
+    /** Current search match position/count, or `undefined` before a search has run. */
+    /** Result summary of the most recent search; undefined until a search runs. */
     searchResults: undefined
   };
 
@@ -318,6 +370,7 @@ export default class Term extends React.PureComponent<
   }
 
   // The main process shows this in the About dialog
+  /** Records the active renderer type/metrics for a terminal and forwards changes to the main process. */
   static reportRenderer(payload: RendererReportPayload) {
     const {uid, type, reason, runtimeMetrics} = payload;
     const hasTypeChanged = Term.rendererTypes[uid] !== type;
@@ -499,6 +552,10 @@ export default class Term extends React.PureComponent<
     terms[this.props.uid] = this;
   }
 
+  /**
+   * Returns the main window `document`. Retained for plugin backwards
+   * compatibility from when each terminal had its own iframe `document`.
+   */
   getTermDocument() {
     console.warn(
       'The underlying terminal engine of Hyper no longer ' +
@@ -510,8 +567,11 @@ export default class Term extends React.PureComponent<
     return document;
   }
 
-  // intercepting paste event for any necessary processing of
-  // clipboard data, if result is falsy, paste event continues
+  /**
+   * Intercepts window paste events for the active pane, letting
+   * `processClipboard` rewrite content before it reaches the terminal. If
+   * nothing is processed, the paste event continues unmodified.
+   */
   onWindowPaste = (e: Event) => {
     if (!this.props.isTermActive) return;
 
@@ -523,6 +583,7 @@ export default class Term extends React.PureComponent<
     }
   };
 
+  /** Copies the current selection on right-click paste (`quickEdit`) or on select (`copyOnSelect`). */
   onMouseUp = (e: React.MouseEvent) => {
     if (this.props.quickEdit && e.button === 2) {
       if (this.term.hasSelection()) {
@@ -536,22 +597,27 @@ export default class Term extends React.PureComponent<
     }
   };
 
+  /** Writes raw data to the terminal, as if it had come from the shell. */
   write(data: string | Uint8Array) {
     this.term.write(data);
   }
 
+  /** Moves keyboard focus into the terminal. */
   focus = () => {
     this.term.focus();
   };
 
+  /** Clears the terminal's scrollback and screen. */
   clear() {
     this.term.clear();
   }
 
+  /** Resets the terminal to its initial state (colours, modes, cursor position). */
   reset() {
     this.term.reset();
   }
 
+  /** Advances the find-in-terminal search to the next match for `searchTerm`. */
   searchNext = (searchTerm: string) => {
     this.searchAddon.findNext(searchTerm, {
       ...this.state.searchOptions,
@@ -559,6 +625,7 @@ export default class Term extends React.PureComponent<
     });
   };
 
+  /** Moves the find-in-terminal search to the previous match for `searchTerm`. */
   searchPrevious = (searchTerm: string) => {
     this.searchAddon.findPrevious(searchTerm, {
       ...this.state.searchOptions,
@@ -566,6 +633,7 @@ export default class Term extends React.PureComponent<
     });
   };
 
+  /** Closes the find-in-terminal search box, clears match decorations, and refocuses the terminal. */
   closeSearchBox = () => {
     this.props.onCloseSearch();
     this.searchAddon.clearDecorations();
@@ -577,15 +645,18 @@ export default class Term extends React.PureComponent<
     this.term.focus();
   };
 
+  /** Resizes the underlying terminal to the given column/row count. */
   resize(size: TerminalSize) {
     const {cols, rows} = size;
     this.term.resize(cols, rows);
   }
 
+  /** Selects the entire terminal buffer. */
   selectAll() {
     this.term.selectAll();
   }
 
+  /** Re-fits the terminal to its wrapper's current size, if the wrapper is mounted. */
   fitResize() {
     if (!this.termWrapperRef) {
       return;
@@ -593,6 +664,10 @@ export default class Term extends React.PureComponent<
     this.fitAddon.fit();
   }
 
+  /**
+   * xterm custom key handler: records keydown timestamps for input-latency
+   * metrics, and lets Mousetrap-flagged command keys bypass terminal input.
+   */
   keyboardHandler = (e: KeyboardEvent & {catched?: boolean}) => {
     // Has Mousetrap flagged this event as a command?
     const shouldProcess = !e.catched;
@@ -741,6 +816,7 @@ export default class Term extends React.PureComponent<
     this.lastFrameTimestamp = null;
   }
 
+  /** Selects the audio played on bell: `sound` if given, the default bell, or none when `bell` is falsy. */
   setBellSound(bell: 'SOUND' | false, sound: string | null) {
     if (bell && bell.toUpperCase() === 'SOUND') {
       this.bellSound = sound ? new Audio(sound) : this.defaultBellSound;
@@ -749,6 +825,7 @@ export default class Term extends React.PureComponent<
     }
   }
 
+  /** Plays the configured bell sound, if any. */
   ringBell() {
     void this.bellSound?.play();
   }
@@ -779,6 +856,7 @@ export default class Term extends React.PureComponent<
     return Math.max(this.webglCooldownMs, this.webglLastFailureAt + this.webglCooldownMs - currentTime);
   }
 
+  /** Handles a lost WebGL context by falling back to the canvas renderer and scheduling a retry. */
   onWebGLContextLoss = () => {
     console.warn('WebGL context lost. Falling back to canvas-based rendering.');
     this.recordWebGLFailure();
@@ -788,6 +866,7 @@ export default class Term extends React.PureComponent<
     this.scheduleDeterministicRendererRetry();
   };
 
+  /** Handles this pane's WebGL context slot being evicted by the shared pool, falling back to canvas. */
   onWebGLEvicted = () => {
     this.recordWebGLFailure();
     this.detachWebGLRenderer();
@@ -795,6 +874,7 @@ export default class Term extends React.PureComponent<
     this.scheduleDeterministicRendererRetry();
   };
 
+  /** Schedules a single retry of renderer selection after a WebGL failure's cooldown elapses. */
   scheduleDeterministicRendererRetry = () => {
     if (this.webglRetryTimer !== null) {
       return;
@@ -806,6 +886,7 @@ export default class Term extends React.PureComponent<
     }, this.getWebGLRetryDelayMs());
   };
 
+  /** Debounces renderer visibility re-checks to at most once per animation frame. */
   scheduleRendererVisibilitySync = () => {
     if (this.visibilityFrame !== null) {
       return;
@@ -857,6 +938,7 @@ export default class Term extends React.PureComponent<
     this.webglLastFailureAt = 0;
   }
 
+  /** Whether the WebGL renderer can be used now, given the theme, browser support, and failure history. */
   canUseWebGLRenderer(hasFailureCooldown = this.hasWebGLFailureCooldown()) {
     if (!this.props.webGLRenderer) {
       return false;
@@ -884,6 +966,7 @@ export default class Term extends React.PureComponent<
     return bounds.right <= 0 || bounds.bottom <= 0 || bounds.left >= viewport.width || bounds.top >= viewport.height;
   }
 
+  /** Whether the pane is outside the viewport or covered by another element at its centre point. */
   isPaneOccluded(bounds: DOMRect) {
     const viewport: ViewportDimensions = {width: window.innerWidth, height: window.innerHeight};
 
@@ -902,6 +985,7 @@ export default class Term extends React.PureComponent<
     return this.termWrapperRef ? !this.termWrapperRef.contains(topElement) : true;
   }
 
+  /** Whether the pane is on the active tab, has non-zero size, and is not occluded. */
   isPaneVisible() {
     if (!this.termWrapperRef) {
       return false;
@@ -915,6 +999,7 @@ export default class Term extends React.PureComponent<
     });
   }
 
+  /** Loads the canvas renderer (and ligature support, unless disabled) and reports the switch. */
   ensureCanvasRenderer(reason?: RendererFallbackReason) {
     if (!this.canvasAddon) {
       this.canvasAddon = new CanvasAddon();
@@ -932,6 +1017,7 @@ export default class Term extends React.PureComponent<
     Term.reportRenderer({uid: asRendererUid(this.props.uid), type: 'Canvas', reason});
   }
 
+  /** Releases this pane's WebGL context pool slot and disposes its WebGL renderer addon. */
   detachWebGLRenderer() {
     webGLPoolReleaseHandlers.delete(this.props.uid);
     sharedWebGLContextPool?.release(this.props.uid);
@@ -942,6 +1028,7 @@ export default class Term extends React.PureComponent<
     }
   }
 
+  /** Acquires a shared WebGL context slot and loads the WebGL renderer, falling back to canvas on failure. */
   ensureWebGLRenderer(webGLContextPool = getWebGLContextPool(this.props.webGLRendererMaxContexts)) {
     try {
       // Acquire/release manages logical slot ownership only. Each pane still
@@ -984,6 +1071,7 @@ export default class Term extends React.PureComponent<
     }
   }
 
+  /** Chooses canvas or WebGL rendering based on pane visibility, theme, and recent WebGL failures. */
   syncRendererForVisibility() {
     if (!this.termRef) {
       return;
@@ -1097,6 +1185,7 @@ export default class Term extends React.PureComponent<
     this.handleActiveRootGroupChange(prevProps);
   }
 
+  /** Ref callback for the wrapper element; wires up a debounced resize observer while mounted. */
   onTermWrapperRef = (component: HTMLElement | null) => {
     this.termWrapperRef = component;
 
@@ -1154,6 +1243,7 @@ export default class Term extends React.PureComponent<
     });
   }
 
+  /** Renders the terminal wrapper and, when `props.search` is set, the find-in-terminal search box. */
   render() {
     return (
       <div

--- a/lib/components/terms.tsx
+++ b/lib/components/terms.tsx
@@ -15,8 +15,14 @@ const TermGroup = decorate(TermGroup_, 'TermGroup');
 
 const isMac = /Mac/.test(navigator.userAgent);
 
+/**
+ * Renders every root term group as a shifted/unshifted tab pane, keeping a
+ * lookup of mounted `Term` instances and wiring plugin-registered commands.
+ */
 export default class Terms extends React.Component<React.PropsWithChildren<TermsProps>> {
+  /** Mounted `Term` instances keyed by session uid. */
   terms: Record<string, Term>;
+  /** Registers plugin command handlers dispatched against this component's actions. */
   registerCommands: (cmds: Record<string, (e: unknown, dispatch: HyperDispatch) => void>) => void;
   constructor(props: TermsProps, context: any) {
     super(props, context);
@@ -32,20 +38,24 @@ export default class Terms extends React.Component<React.PropsWithChildren<Terms
     );
   }
 
+  /** Registers a mounted `Term` instance under its session uid. */
   onRef = (uid: string, term: Term | null) => {
     if (term) {
       this.terms[uid] = term;
     }
   };
 
+  /** Returns the mounted `Term` instance for a session uid, if any. */
   getTermByUid(uid: string) {
     return this.terms[uid];
   }
 
+  /** Returns the mounted `Term` instance for the currently active session. */
   getActiveTerm() {
     return this.getTermByUid(this.props.activeSession!);
   }
 
+  /** Registers a mounted `Term` instance under its session uid. */
   onTerminal(uid: string, term: Term) {
     this.terms[uid] = term;
   }
@@ -73,6 +83,7 @@ export default class Terms extends React.Component<React.PropsWithChildren<Terms
     this.props.ref_(null);
   }
 
+  /** Renders each root term group's tab pane, shifting the layout when multiple tabs are open on non-mac. */
   render() {
     const shift = !isMac && this.props.termGroups.length > 1;
     return (

--- a/lib/containers/header.ts
+++ b/lib/containers/header.ts
@@ -49,56 +49,76 @@ const getTabs = createSelector(
 const mapStateToProps = (state: HyperState) => {
   return {
     // active is an index
+    /** Whether the renderer is running on macOS, so chrome can match platform conventions. */
     isMac,
+    /** Memoized tab list, including activity and active-state flags, for the tab strip. */
     tabs: getTabs(state),
+    /** Raw activity markers keyed by session, used to badge tabs with pending output. */
     activeMarkers: state.ui.activityMarkers,
+    /** Window border colour, sourced from the active theme/config. */
     borderColor: state.ui.borderColor,
+    /** Header background colour, sourced from the active theme/config. */
     backgroundColor: state.ui.backgroundColor,
+    /** Whether the window is currently maximized, to pick the correct restore control. */
     maximized: state.ui.maximized,
+    /** Whether the window is in fullscreen, which hides the native window controls. */
     fullScreen: state.ui.fullScreen,
+    /** Whether the hamburger menu control should be shown in the header. */
     showHamburgerMenu: state.ui.showHamburgerMenu,
+    /** Whether native-style window controls (minimize/maximize/close) should be shown. */
     showWindowControls: state.ui.showWindowControls,
+    /** Id of the shell profile used when a new tab is opened without an explicit choice. */
     defaultProfile: state.ui.defaultProfile,
+    /** Shell profiles offered in the new-tab menu. */
     profiles: state.ui.profiles
   };
 };
 
 const mapDispatchToProps = (dispatch: HyperDispatch) => {
   return {
+    /** Closes the tab with the given uid. */
     onCloseTab: (i: string) => {
       dispatch(closeTab(i));
     },
 
+    /** Makes the tab with the given uid active. */
     onChangeTab: (i: string) => {
       dispatch(changeTab(i));
     },
 
+    /** Maximizes the application window. */
     maximize: () => {
       dispatch(maximize());
     },
 
+    /** Restores the application window from a maximized state. */
     unmaximize: () => {
       dispatch(unmaximize());
     },
 
+    /** Opens the hamburger menu at the given screen coordinates. */
     openHamburgerMenu: (coordinates: {x: number; y: number}) => {
       dispatch(openHamburgerMenu(coordinates));
     },
 
+    /** Minimizes the application window. */
     minimize: () => {
       dispatch(minimize());
     },
 
+    /** Closes the application window. */
     close: () => {
       dispatch(close());
     },
 
+    /** Opens a new tab using the given shell profile. */
     openNewTab: (profile: string) => {
       dispatch(requestTermGroup({profile}));
     }
   };
 };
 
+/** Header component with translated aria labels applied to its window controls. */
 export const HeaderWithTranslation = (props: HeaderConnectedProps) => {
   const t = useTranslation();
 
@@ -112,6 +132,8 @@ export const HeaderWithTranslation = (props: HeaderConnectedProps) => {
   });
 };
 
+/** Header chrome connected to renderer state and header actions. */
 export const HeaderContainer = connect(mapStateToProps, mapDispatchToProps, null)(HeaderWithTranslation, 'Header');
 
+/** Props supplied to the header by `connect`, combining state selections and dispatch bindings. */
 export type HeaderConnectedProps = ReturnType<typeof mapStateToProps> & ReturnType<typeof mapDispatchToProps>;

--- a/lib/containers/hyper.tsx
+++ b/lib/containers/hyper.tsx
@@ -136,28 +136,40 @@ Hyper.displayName = 'Hyper';
 
 const mapStateToProps = (state: HyperState) => {
   return {
+    /** Whether the renderer is running on macOS, so chrome can match platform conventions. */
     isMac,
+    /** User-supplied custom CSS, scoped to the `#hyper` container and injected at render time. */
     customCSS: state.ui.css,
+    /** Font family applied to header and other chrome text. */
     uiFontFamily: state.ui.uiFontFamily,
+    /** Window border colour, sourced from the active theme/config. */
     borderColor: state.ui.borderColor,
+    /** Uid of the currently active session, used to keep terminal focus in sync. */
     activeSession: state.sessions.activeUid,
+    /** Window background colour, sourced from the active theme/config. */
     backgroundColor: state.ui.backgroundColor,
+    /** Whether the window is currently maximized, used to size the border. */
     maximized: state.ui.maximized,
+    /** Whether the window is in fullscreen, toggling the rounded-corner chrome. */
     fullScreen: state.ui.fullScreen,
+    /** Timestamp of the last config update, used to re-attach key listeners on config change. */
     lastConfigUpdate: state.ui._lastUpdate
   };
 };
 
 const mapDispatchToProps = (dispatch: HyperDispatch) => {
   return {
+    /** Runs a registered command handler for the given keybinding-triggered command. */
     execCommand: (command: CommandId, fn: ((e: unknown, dispatch: HyperDispatch) => void) | undefined, e: unknown) => {
       dispatch(uiActions.execCommand(command, fn, e));
     }
   };
 };
 
+/** Top-level Hyper window container, connected to renderer state and command dispatch. */
 const HyperContainer = connect(mapStateToProps, mapDispatchToProps, null, {forwardRef: true})(Hyper, 'Hyper');
 
 export default HyperContainer;
 
+/** Props supplied to the Hyper window by `connect`, combining state selections and dispatch bindings. */
 export type HyperConnectedProps = ReturnType<typeof mapStateToProps> & ReturnType<typeof mapDispatchToProps>;

--- a/lib/containers/notifications.ts
+++ b/lib/containers/notifications.ts
@@ -8,20 +8,35 @@ const mapStateToProps = (state: HyperState) => {
   const {ui} = state;
   const {notifications} = ui;
   let state_: Partial<{
+    /** Shows the transient font-size notification while a font-size change is pending. */
     fontShowing: boolean;
+    /** Font size in points, used to compute `fontText`. */
     fontSize: number;
+    /** Formatted font-size label (e.g. `14px`) shown in the notification. */
     fontText: string;
+    /** Shows the transient resize notification while a terminal resize is pending. */
     resizeShowing: boolean;
+    /** Terminal column count shown in the resize notification. */
     cols: number | null;
+    /** Terminal row count shown in the resize notification. */
     rows: number | null;
+    /** Shows the update-available notification. */
     updateShowing: boolean;
+    /** Version string of the available update, shown in the notification. */
     updateVersion: string | null;
+    /** First line of the update's release notes, shown in the notification. */
     updateNote: string | null;
+    /** Release page URL linked from the update notification. */
     updateReleaseUrl: string | null;
+    /** Whether the available update can be installed from within the app. */
     updateCanInstall: boolean | null;
+    /** Shows the generic message notification. */
     messageShowing: boolean;
+    /** Body text of the generic message notification. */
     messageText: string | null;
+    /** Optional link URL associated with the generic message notification. */
     messageURL: string | null;
+    /** Whether the user can dismiss the generic message notification. */
     messageDismissable: boolean | null;
   }> = {};
 
@@ -72,26 +87,33 @@ const mapStateToProps = (state: HyperState) => {
 
 const mapDispatchToProps = (dispatch: HyperDispatch) => {
   return {
+    /** Dismisses the font-size notification. */
     onDismissFont: () => {
       dispatch(dismissNotification('font'));
     },
+    /** Dismisses the resize notification. */
     onDismissResize: () => {
       dispatch(dismissNotification('resize'));
     },
+    /** Dismisses the update-available notification. */
     onDismissUpdate: () => {
       dispatch(dismissNotification('updates'));
     },
+    /** Dismisses the generic message notification. */
     onDismissMessage: () => {
       dispatch(dismissNotification('message'));
     },
+    /** Installs the pending application update. */
     onUpdateInstall: () => {
       dispatch(installUpdate());
     }
   };
 };
 
+/** Transient notification banners (font size, resize, update, message), connected to renderer state. */
 const NotificationsContainer = connect(mapStateToProps, mapDispatchToProps, null)(Notifications, 'Notifications');
 
 export default NotificationsContainer;
 
+/** Props supplied to the notifications banner by `connect`, combining state selections and dispatch bindings. */
 export type NotificationsConnectedProps = ReturnType<typeof mapStateToProps> & ReturnType<typeof mapDispatchToProps>;

--- a/lib/containers/terms.ts
+++ b/lib/containers/terms.ts
@@ -18,76 +18,124 @@ import {connect} from '../utils/plugins';
 const mapStateToProps = (state: HyperState) => {
   const {sessions} = state.sessions;
   return {
+    /** All sessions keyed by uid, backing the terms rendered for each pane. */
     sessions,
+    /** Terminal column count, when not driven by pane auto-fit. */
     cols: state.ui.cols,
+    /** Terminal row count, when not driven by pane auto-fit. */
     rows: state.ui.rows,
+    /** Number of scrollback lines retained per terminal. */
     scrollback: state.ui.scrollback,
+    /** Root term-group tree describing the current split layout. */
     termGroups: getRootGroups(state),
+    /** Uid of the root term group whose tab is currently active. */
     activeRootGroup: state.termGroups.activeRootGroup,
+    /** Uid of the currently focused session, used to mark its terminal active. */
     activeSession: state.sessions.activeUid,
+    /** User-supplied CSS injected into every terminal pane. */
     customCSS: state.ui.termCSS,
+    /** Whether pty writes are permitted, used to gate terminal input. */
     write: state.sessions.write,
+    /** Effective font size, honouring any temporary font-size override. */
     fontSize: state.ui.fontSizeOverride ? state.ui.fontSizeOverride : state.ui.fontSize,
+    /** Terminal font family. */
     fontFamily: state.ui.fontFamily,
+    /** Terminal font weight for regular text. */
     fontWeight: state.ui.fontWeight,
+    /** Terminal font weight for bold text. */
     fontWeightBold: state.ui.fontWeightBold,
+    /** Terminal line height multiplier. */
     lineHeight: state.ui.lineHeight,
+    /** Terminal letter spacing, in pixels. */
     letterSpacing: state.ui.letterSpacing,
+    /** Font family used for UI chrome such as the search box. */
     uiFontFamily: state.ui.uiFontFamily,
+    /** Font-smoothing override applied to terminal text rendering. */
     fontSmoothing: state.ui.fontSmoothingOverride,
+    /** CSS padding applied inside each terminal pane. */
     padding: state.ui.padding,
+    /** Cursor colour. */
     cursorColor: state.ui.cursorColor,
+    /** Cursor accent colour, used with block cursors to colour the character underneath. */
     cursorAccentColor: state.ui.cursorAccentColor,
+    /** Cursor shape (bar, underline, or block). */
     cursorShape: state.ui.cursorShape,
+    /** Whether the cursor blinks. */
     cursorBlink: state.ui.cursorBlink,
+    /** Border colour used for pane dividers and other terminal chrome. */
     borderColor: state.ui.borderColor,
+    /** Selection highlight colour. */
     selectionColor: state.ui.selectionColor,
+    /** ANSI colour palette applied to terminal output. */
     colors: state.ui.colors,
+    /** Terminal foreground (text) colour. */
     foregroundColor: state.ui.foregroundColor,
+    /** Terminal background colour. */
     backgroundColor: state.ui.backgroundColor,
+    /** Bell mode, controlling whether the terminal bell plays a sound. */
     bell: state.ui.bell,
+    /** URL of a user-supplied bell sound file. */
     bellSoundURL: state.ui.bellSoundURL,
+    /** Base64-encoded bell sound data, when configured inline rather than by URL. */
     bellSound: state.ui.bellSound,
+    /** Whether selecting text also copies it to the clipboard. */
     copyOnSelect: state.ui.copyOnSelect,
+    /** Modifier-key behaviour overrides (e.g. treating Option as Meta on macOS). */
     modifierKeys: state.ui.modifierKeys,
+    /** Enables the right-click quick-edit copy/paste shortcut. */
     quickEdit: state.ui.quickEdit,
+    /** Whether the WebGL renderer is enabled. */
     webGLRenderer: state.ui.webGLRenderer,
+    /** Maximum number of concurrent WebGL contexts shared across terminals. */
     webGLRendererMaxContexts: state.ui.webGLRendererMaxContexts,
+    /** Modifier key that must be held to activate clickable web links. */
     webLinksActivationKey: state.ui.webLinksActivationKey,
+    /** macOS Option-key selection mode (e.g. force rectangular selection). */
     macOptionSelectionMode: state.ui.macOptionSelectionMode,
+    /** Disables font ligature rendering. */
     disableLigatures: state.ui.disableLigatures,
+    /** Enables accessibility-friendly rendering for screen readers. */
     screenReaderMode: state.ui.screenReaderMode,
+    /** Windows-specific pty configuration (e.g. ConPTY options). */
     windowsPty: state.ui.windowsPty,
+    /** Enables inline image rendering (Sixel/iTerm2 image protocols) in the terminal. */
     imageSupport: state.ui.imageSupport
   };
 };
 
 const mapDispatchToProps = (dispatch: HyperDispatch) => {
   return {
+    /** Forwards terminal input to the session's pty. */
     onData(uid: string, data: string) {
       dispatch(sendSessionData({uid, data}));
     },
 
+    /** Updates the session's title from an xterm title-change event. */
     onTitle(uid: string, title: string) {
       dispatch(setSessionXtermTitle(uid, title));
     },
 
+    /** Records a terminal resize so the pty can be resized to match. */
     onResize(uid: string, cols: number, rows: number) {
       dispatch(resizeSession(uid, cols, rows));
     },
 
+    /** Marks the session active when its terminal gains focus. */
     onActive(uid: string) {
       dispatch(setActiveSession(uid));
     },
 
+    /** Opens the find-in-terminal search box for the session. */
     onOpenSearch(uid: string) {
       dispatch(openSearch(uid));
     },
 
+    /** Closes the find-in-terminal search box for the session. */
     onCloseSearch(uid: string) {
       dispatch(closeSearch(uid));
     },
 
+    /** Activates the session and opens its context menu for the given selection. */
     onContextMenu(uid: string, selection: string) {
       dispatch(setActiveSession(uid));
       dispatch(openContextMenu(uid, selection));
@@ -95,9 +143,11 @@ const mapDispatchToProps = (dispatch: HyperDispatch) => {
   };
 };
 
+/** Props supplied to the terminal group by `connect`, combining state selections and dispatch bindings. */
 export type TermsConnectedProps = ReturnType<typeof mapStateToProps> & ReturnType<typeof mapDispatchToProps>;
 type TermsContainerProps = Omit<React.ComponentProps<typeof Terms>, keyof TermsConnectedProps>;
 
+/** Terminal group container, connected to session state, terminal styling, and session actions. */
 const TermsContainer = connect(mapStateToProps, mapDispatchToProps, null, {forwardRef: true})(
   Terms,
   'Terms'

--- a/lib/context-key-expression.ts
+++ b/lib/context-key-expression.ts
@@ -1,4 +1,8 @@
-/** @file Public `when` parser and evaluator exports. */
+/**
+ * Public `when` parser and evaluator exports.
+ *
+ * @module
+ */
 export {
   compileWhenExpression,
   parseWhenExpression,

--- a/lib/context-key-syntax-error.ts
+++ b/lib/context-key-syntax-error.ts
@@ -3,7 +3,9 @@ import type {WhenExpressionParseError} from '@shared/types/context-keys';
 
 /** Structured parse error with stable source/index metadata. */
 export class WhenExpressionSyntaxError extends SyntaxError implements WhenExpressionParseError {
+  /** The `when` expression source that failed to parse. */
   readonly source: string;
+  /** Character offset in `source` at which parsing failed. */
   readonly index: number;
 
   constructor(message: string, source: string, index: number) {

--- a/lib/context-key-tokenizer.ts
+++ b/lib/context-key-tokenizer.ts
@@ -3,9 +3,21 @@ import type {ContextKeyValue, WhenComparisonOperator} from '@shared/types/contex
 
 import {WhenExpressionSyntaxError} from './context-key-syntax-error';
 
+/** Category of a `when` expression token. */
 export type TokenKind = 'identifier' | 'literal' | 'operator' | 'lparen' | 'rparen' | 'eof';
-export type Token = {kind: TokenKind; lexeme: string; index: number; literal?: ContextKeyValue};
+/** A single lexical token produced by {@link tokenize}. */
+export type Token = {
+  /** The token's category. */
+  kind: TokenKind;
+  /** The raw source text that produced this token. */
+  lexeme: string;
+  /** Character offset in the source at which this token begins. */
+  index: number;
+  /** Decoded value, present for `literal` tokens. */
+  literal?: ContextKeyValue;
+};
 
+/** Comparison operators recognized in `when` expressions, ordered longest-match first. */
 export const COMPARISON_OPERATORS: readonly WhenComparisonOperator[] = ['==', '!=', '<', '<=', '>', '>='];
 const TWO_CHAR_OPERATORS = ['&&', '||', ...COMPARISON_OPERATORS] as const;
 const SINGLE_CHAR_OPERATORS = ['!', '<', '>'] as const;

--- a/lib/hooks/use-config-reloadability.ts
+++ b/lib/hooks/use-config-reloadability.ts
@@ -33,11 +33,23 @@ export type UseConfigReloadabilityReturn = {
   /** Function to get classification for any key. */
   getClassification: (key: string) => Reloadability | undefined;
   /** Function to get full reloadability entry with rationale. */
-  getReloadabilityEntry: (key: string) => {classification: Reloadability; rationale: string} | undefined;
+  getReloadabilityEntry: (key: string) =>
+    | {
+        /** The reload classification for the key. */
+        classification: Reloadability;
+        /** Human-readable explanation for the classification. */
+        rationale: string;
+      }
+    | undefined;
   /** Function to filter keys by classification (includes unknown keys when classification is 'restart'). */
   filterKeysByClassification: (keys: string[], classification: Reloadability) => string[];
   /** Function to partition keys by reloadability (unknown keys default to restart). */
-  partitionKeys: (keys: string[]) => {live: string[]; restart: string[]};
+  partitionKeys: (keys: string[]) => {
+    /** Keys that can be applied without a restart. */
+    live: string[];
+    /** Keys that require a restart to take effect. */
+    restart: string[];
+  };
 };
 
 /**
@@ -46,7 +58,16 @@ export type UseConfigReloadabilityReturn = {
  * @param key - The configuration key.
  * @returns The reloadability entry with classification and rationale, or undefined.
  */
-export const getReloadabilityEntry = (key: string): {classification: Reloadability; rationale: string} | undefined => {
+export const getReloadabilityEntry = (
+  key: string
+):
+  | {
+      /** The reload classification for the key. */
+      classification: Reloadability;
+      /** Human-readable explanation for the classification. */
+      rationale: string;
+    }
+  | undefined => {
   const scope = getKeyScope(key);
   const entry = getReloadability(key, scope);
   return entry ? {classification: entry.classification, rationale: entry.rationale} : undefined;
@@ -81,7 +102,14 @@ export const filterKeysByClassification = (keys: string[], classification: Reloa
  * @param keys - Array of configuration keys to partition.
  * @returns Object with live and restart arrays.
  */
-export const partitionKeys = (keys: string[]): {live: string[]; restart: string[]} => {
+export const partitionKeys = (
+  keys: string[]
+): {
+  /** Keys that can be applied without a restart. */
+  live: string[];
+  /** Keys that require a restart to take effect. */
+  restart: string[];
+} => {
   const live: string[] = [];
   const restart: string[] = [];
 

--- a/lib/hooks/use-translation.ts
+++ b/lib/hooks/use-translation.ts
@@ -61,6 +61,7 @@ const getTranslationDictionary = (locale: string) => {
   return translationDictionaries[normalizedLocale] ?? translationDictionaries[language] ?? headerLabelDefaults;
 };
 
+/** Returns a lookup function for header accessibility labels in the user's preferred locale. */
 export const useTranslation = () => {
   const translationDictionary = getTranslationDictionary(getPreferredLocale());
 

--- a/lib/reducers/index.ts
+++ b/lib/reducers/index.ts
@@ -23,6 +23,9 @@ const reducers: ReducersMapObject<HyperState, HyperActions> = {
   termGroups
 };
 
+/** Combined root reducer for the renderer store. */
 const rootReducer = combineReducers(reducers);
 
+/** Root Redux reducer composing the `ui`, `sessions`, and `termGroups` slices. */
+/** Combined root reducer for the renderer store. */
 export default rootReducer;

--- a/lib/reducers/sessions.ts
+++ b/lib/reducers/sessions.ts
@@ -132,4 +132,5 @@ const reducer: ISessionReducer = (state = initialState, action) => {
   }
 };
 
+/** Sessions reducer, plugin-decorated to allow plugins to intercept and extend session state changes. */
 export default decorateSessionsReducer(reducer);

--- a/lib/reducers/term-groups.ts
+++ b/lib/reducers/term-groups.ts
@@ -226,4 +226,5 @@ const reducer: ITermGroupReducer = (state = initialState, action) => {
   }
 };
 
+/** Term groups reducer, plugin-decorated to allow plugins to intercept and extend layout state changes. */
 export default decorateTermGroupsReducer(reducer);

--- a/lib/reducers/ui.ts
+++ b/lib/reducers/ui.ts
@@ -872,4 +872,5 @@ const reducer: IUiReducer = (state = initial, action) => {
   return state_;
 };
 
+/** UI reducer, plugin-decorated to allow plugins to intercept and extend UI state changes. */
 export default decorateUIReducer(reducer);

--- a/lib/rpc.ts
+++ b/lib/rpc.ts
@@ -1,5 +1,8 @@
 import RPC from './utils/rpc';
 
+/** Shared renderer RPC client instance. */
 const rpc = new RPC();
 
+/** Singleton renderer RPC client shared across the application. */
+/** Shared renderer RPC client instance. */
 export default rpc;

--- a/lib/selectors.ts
+++ b/lib/selectors.ts
@@ -3,6 +3,7 @@ import {createSelector} from 'reselect';
 import type {HyperState} from '../typings/hyper';
 
 const getTermGroups = ({termGroups}: Pick<HyperState, 'termGroups'>) => termGroups.termGroups;
+/** Selects the root term groups (tabs), i.e. those without a parent. */
 export const getRootGroups = createSelector(getTermGroups, (termGroups) =>
   Object.keys(termGroups)
     .map((uid) => termGroups[uid])

--- a/lib/store/configure-store.dev.ts
+++ b/lib/store/configure-store.dev.ts
@@ -19,10 +19,13 @@ import * as plugins from '../utils/plugins';
 
 import writeMiddleware from './write-middleware';
 
+/** Build the development store with logging and hot-reload support. */
 const configureStoreForDevelopment = () => {
   const enhancer = composeWithDevTools(applyMiddleware(thunk, plugins.middleware, writeMiddleware, effects));
 
   return createStore(rootReducer, undefined, enhancer);
 };
 
+/** Creates the development Redux store with thunk, plugin, write, and effects middleware, plus DevTools. */
+/** Build the development store with logging and hot-reload support. */
 export default configureStoreForDevelopment;

--- a/lib/store/configure-store.prod.ts
+++ b/lib/store/configure-store.prod.ts
@@ -17,7 +17,10 @@ import * as plugins from '../utils/plugins';
 
 import writeMiddleware from './write-middleware';
 
+/** Build the production store with the minimal middleware chain. */
 const configureStoreForProd = () =>
   createStore(rootReducer, undefined, applyMiddleware(thunk, plugins.middleware, writeMiddleware, effects));
 
+/** Creates the production Redux store with thunk, plugin, write, and effects middleware. */
+/** Build the production store with the minimal middleware chain. */
 export default configureStoreForProd;

--- a/lib/store/configure-store.ts
+++ b/lib/store/configure-store.ts
@@ -1,6 +1,7 @@
 import configureStoreForDevelopment from './configure-store.dev';
 import configureStoreForProduction from './configure-store.prod';
 
+/** Builds the Redux store, selecting the production or development configuration by `NODE_ENV`. */
 const configureStore = () => {
   if (process.env.NODE_ENV === 'production') {
     return configureStoreForProduction();

--- a/lib/store/write-middleware.ts
+++ b/lib/store/write-middleware.ts
@@ -27,6 +27,7 @@ const isSessionPtyDataAction = (action: unknown): action is SessionPtyDataAction
   );
 };
 
+/** Middleware forwarding SESSION_USER_DATA writes to the active session. */
 const writeMiddleware: Middleware<{}, HyperState, Dispatch<HyperActions>> = () => (next) => (action) => {
   if (isSessionPtyDataAction(action)) {
     const term = terms[action.uid];
@@ -37,4 +38,6 @@ const writeMiddleware: Middleware<{}, HyperState, Dispatch<HyperActions>> = () =
   return next(action);
 };
 
+/** Redux middleware writing PTY output directly to the matching terminal, bypassing React reconciliation. */
+/** Middleware forwarding SESSION_USER_DATA writes to the active session. */
 export default writeMiddleware;

--- a/lib/terms.ts
+++ b/lib/terms.ts
@@ -7,5 +7,8 @@ import type Term from './components/term';
 // optimization for the most common action
 // within the system
 
+/** Registry of mounted terminal instances, keyed by session uid. */
 const terms: Record<string, Term | null> = {};
+/** Registry of mounted `Term` instances by session uid, for imperative access outside React. */
+/** Registry of mounted terminal instances, keyed by session uid. */
 export default terms;

--- a/lib/transport/index.ts
+++ b/lib/transport/index.ts
@@ -1,2 +1,6 @@
-/** @file Transport accessor — single composition boundary for host adapter. */
+/**
+ * Transport accessor — single composition boundary for host adapter.
+ *
+ * @module
+ */
 export {transport} from './electron-ipc-transport';

--- a/lib/transport/ipc-schemas.ts
+++ b/lib/transport/ipc-schemas.ts
@@ -23,7 +23,9 @@ import type {IpcCommands} from '@shared/types/common';
 const stdioValueSchema = z.union([z.string(), z.instanceof(Uint8Array)]);
 
 const childProcessResultSchema = z.object({
+  /** Captured standard output from the spawned process. */
   stdout: stdioValueSchema,
+  /** Captured standard error from the spawned process. */
   stderr: stdioValueSchema
 });
 
@@ -36,21 +38,37 @@ const fontWeightSchema: ZodType<FontWeight> = z.union([
 /** Terminal colour palette. */
 const colorMapSchema = z
   .object({
+    /** ANSI black, used for both the palette entry and cursor contrast. */
     black: z.string(),
+    /** ANSI blue. */
     blue: z.string(),
+    /** ANSI cyan. */
     cyan: z.string(),
+    /** ANSI green. */
     green: z.string(),
+    /** Bright variant of ANSI black, used for high-intensity escape codes. */
     lightBlack: z.string(),
+    /** Bright variant of ANSI blue. */
     lightBlue: z.string(),
+    /** Bright variant of ANSI cyan. */
     lightCyan: z.string(),
+    /** Bright variant of ANSI green. */
     lightGreen: z.string(),
+    /** Bright variant of ANSI magenta. */
     lightMagenta: z.string(),
+    /** Bright variant of ANSI red. */
     lightRed: z.string(),
+    /** Bright variant of ANSI white. */
     lightWhite: z.string(),
+    /** Bright variant of ANSI yellow. */
     lightYellow: z.string(),
+    /** ANSI magenta. */
     magenta: z.string(),
+    /** ANSI red. */
     red: z.string(),
+    /** ANSI white. */
     white: z.string(),
+    /** ANSI yellow. */
     yellow: z.string()
   })
   .passthrough();
@@ -58,50 +76,110 @@ const colorMapSchema = z
 /** Profile-level configuration fields. */
 const profileConfigSchema = z
   .object({
+    /** Terminal background colour. */
     backgroundColor: z.string(),
+    /** Whether the bell plays a sound or is disabled entirely. */
     bell: z.union([z.literal('SOUND'), z.literal(false)]),
+    /** Path to a custom bell sound file, or null to use the built-in sound. */
     bellSound: z.string().nullable(),
+    /** URL of a custom bell sound, resolved from `bellSound` at load time. */
     bellSoundURL: z.string().nullable(),
+    /** Colour of the window border/frame. */
     borderColor: z.string(),
+    /** ANSI colour palette used to render terminal escape sequences. */
     colors: colorMapSchema,
+    /** Whether selecting text also copies it to the clipboard. */
     copyOnSelect: z.boolean(),
+    /** Raw CSS injected into the terminal window for user styling. */
     css: z.string(),
+    /** Accent colour drawn around the cursor. */
     cursorAccentColor: z.string(),
+    /** Whether the cursor blinks while idle. */
     cursorBlink: z.boolean(),
+    /** Cursor fill/outline colour. */
     cursorColor: z.string(),
-    cursorShape: z.enum(['BEAM', 'UNDERLINE', 'BLOCK']),
+    /** Visual style used to render the cursor. */
+    cursorShape: z.enum([
+      /** Thin vertical bar cursor. */
+      'BEAM',
+      /** Underline cursor. */
+      'UNDERLINE',
+      /** Solid block cursor. */
+      'BLOCK'
+    ]),
+    /** Whether font ligatures are disabled. */
     disableLigatures: z.boolean(),
+    /** Extra environment variables merged into the shell's environment. */
     env: z.record(z.string(), z.string()),
+    /** Terminal font family. */
     fontFamily: z.string(),
+    /** Terminal font size, in pixels. */
     fontSize: z.number(),
+    /** Font weight used for normal-intensity text. */
     fontWeight: fontWeightSchema,
+    /** Font weight used for bold-intensity text. */
     fontWeightBold: fontWeightSchema,
+    /** Terminal foreground (text) colour. */
     foregroundColor: z.string(),
+    /** Whether inline image rendering (e.g. sixel) is enabled. */
     imageSupport: z.boolean(),
+    /** Extra spacing added between characters, in pixels. */
     letterSpacing: z.number(),
+    /** Line height multiplier applied to terminal rows. */
     lineHeight: z.number(),
+    /** Platform-specific behaviour for Option-key text selection on macOS. */
     macOptionSelectionMode: z.string(),
+    /** Overrides for how modifier keys are interpreted by the terminal. */
     modifierKeys: z
       .object({
+        /** Whether Alt is treated as the Meta key. */
         altIsMeta: z.boolean(),
+        /** Whether Cmd is treated as the Meta key. */
         cmdIsMeta: z.boolean()
       })
       .optional(),
+    /** CSS padding applied around the terminal content area. */
     padding: z.string(),
+    /** Whether new tabs/splits inherit the current working directory. */
     preserveCWD: z.boolean(),
+    /** Whether quick-edit (right-click paste) mode is enabled. */
     quickEdit: z.boolean(),
+    /** Whether accessibility support for screen readers is enabled. */
     screenReaderMode: z.boolean(),
+    /** Number of lines retained in the terminal's scrollback buffer. */
     scrollback: z.number(),
+    /** Colour used to highlight selected text. */
     selectionColor: z.string(),
+    /** Path to the shell executable launched for new sessions. */
     shell: z.string(),
+    /** Arguments passed to the shell executable on launch. */
     shellArgs: z.array(z.string()),
+    /** Whether the hamburger menu is shown, and where. */
     showHamburgerMenu: z.union([z.boolean(), z.literal('')]),
+    /** Whether native window controls are shown, and on which side. */
     showWindowControls: z.union([z.boolean(), z.literal('left'), z.literal('')]),
+    /** Raw CSS injected specifically into the xterm.js term element. */
     termCSS: z.string(),
+    /** Font family used for Hyper's own UI chrome, distinct from the terminal font. */
     uiFontFamily: z.string().optional(),
+    /** Whether the WebGL renderer is used instead of the canvas renderer. */
     webGLRenderer: z.boolean(),
-    webLinksActivationKey: z.enum(['ctrl', 'alt', 'meta', 'shift', '']),
+    /** Modifier key that must be held to activate clickable web links. */
+    webLinksActivationKey: z.enum([
+      /** Require the Ctrl key. */
+      'ctrl',
+      /** Require the Alt key. */
+      'alt',
+      /** Require the Meta (Cmd/Win) key. */
+      'meta',
+      /** Require the Shift key. */
+      'shift',
+      /** No modifier required; links activate on plain click. */
+      ''
+    ]),
+    /** Initial terminal window size, as [columns, rows]. */
     windowSize: z.tuple([z.number(), z.number()]).optional(),
+    /** Initial working directory for new sessions. */
     workingDirectory: z.string()
   })
   .passthrough();
@@ -109,10 +187,20 @@ const profileConfigSchema = z
 /** Root-level configuration fields. */
 const rootConfigSchema = z
   .object({
+    /** Whether plugins are updated automatically, or a specific update policy string. */
     autoUpdatePlugins: z.union([z.boolean(), z.string()]),
+    /** Whether SSH sessions launch the default SSH app instead of Hyper's own client. */
     defaultSSHApp: z.boolean(),
+    /** Whether automatic application updates are disabled. */
     disableAutoUpdates: z.boolean(),
-    updateChannel: z.enum(['stable', 'canary']),
+    /** Release channel used when checking for application updates. */
+    updateChannel: z.enum([
+      /** Fully tested, general-availability releases. */
+      'stable',
+      /** Pre-release builds for early feedback. */
+      'canary'
+    ]),
+    /** Whether the ConPTY backend is used for Windows shell sessions. */
     useConpty: z.boolean().optional()
   })
   .passthrough();
@@ -121,11 +209,15 @@ const rootConfigSchema = z
 const configOptionsSchema = rootConfigSchema
   .merge(profileConfigSchema)
   .extend({
+    /** Name of the profile used when a session does not request one explicitly. */
     defaultProfile: z.string(),
+    /** Named configuration profiles that can override the root/default settings. */
     profiles: z.array(
       z
         .object({
+          /** Profile name, referenced by `defaultProfile` and session requests. */
           name: z.string(),
+          /** Partial profile overrides applied on top of the default configuration. */
           config: profileConfigSchema.partial()
         })
         .passthrough()
@@ -136,19 +228,35 @@ const configOptionsSchema = rootConfigSchema
 /** Shared command-definition payload used by runtime plugin command sync. */
 const commandDefinitionSchema = z
   .object({
+    /** Stable identifier for the command, unique within its registering plugin. */
     id: z.string(),
-    kind: z.enum(['frontend', 'backend']),
+    /** Whether the command runs in the renderer (frontend) or main (backend) process. */
+    kind: z.enum([
+      /** Executes in the renderer process. */
+      'frontend',
+      /** Executes in the main process. */
+      'backend'
+    ]),
+    /** Display metadata used to present the command in menus and palettes. */
     metadata: z
       .object({
+        /** Human-readable command name. */
         title: z.string(),
+        /** Grouping used to organize commands in menus. */
         category: z.string().optional(),
+        /** Longer explanation shown in command palette tooltips. */
         description: z.string().optional(),
+        /** Search terms that help users find the command. */
         keywords: z.array(z.string()).optional(),
+        /** Icon identifier shown alongside the command. */
         icon: z.string().optional()
       })
       .passthrough(),
+    /** Expression controlling when the command is the default for its context. */
     defaultWhen: z.string().optional(),
+    /** Schema describing the arguments the command accepts, if any. */
     argsSchema: z.record(z.string(), z.unknown()).optional(),
+    /** Schema describing the command's result payload, if any. */
     resultSchema: z.record(z.string(), z.unknown()).optional()
   })
   .passthrough();
@@ -168,15 +276,51 @@ const commandDefinitionSchema = z
  * properties as optional (`$loose` mode); runtime validation is the purpose
  * of this registry, and the `RendererCommandTransport` interface already
  * guarantees the correct return type at call sites.
+ *
+ * @internal
  */
 export const ipcResponseSchemas = {
+  /** Response for `child_process.exec`: captured stdout/stderr of the run. */
   'child_process.exec': childProcessResultSchema,
+  /** Response for `child_process.execFile`: captured stdout/stderr of the run. */
   'child_process.execFile': childProcessResultSchema,
-  getLoadedPluginVersions: z.array(z.object({name: z.string(), version: z.string()})),
-  getPaths: z.object({plugins: z.array(z.string()), localPlugins: z.array(z.string())}),
-  getBasePaths: z.object({path: z.string(), localPath: z.string()}),
-  getDeprecatedConfig: z.record(z.string(), z.object({css: z.array(z.string())}).passthrough()),
+  /** Response for `getLoadedPluginVersions`: name/version pairs for active plugins. */
+  getLoadedPluginVersions: z.array(
+    z.object({
+      /** Plugin package name. */
+      name: z.string(),
+      /** Installed plugin version string. */
+      version: z.string()
+    })
+  ),
+  /** Response for `getPaths`: filesystem locations of installed plugins. */
+  getPaths: z.object({
+    /** Plugins installed from the registry. */
+    plugins: z.array(z.string()),
+    /** Plugins loaded from the user's local plugin directory. */
+    localPlugins: z.array(z.string())
+  }),
+  /** Response for `getBasePaths`: root directories used to resolve plugin paths. */
+  getBasePaths: z.object({
+    /** Base path for registry-installed plugins. */
+    path: z.string(),
+    /** Base path for locally developed plugins. */
+    localPath: z.string()
+  }),
+  /** Response for `getDeprecatedConfig`: legacy per-plugin CSS overrides still in use. */
+  getDeprecatedConfig: z.record(
+    z.string(),
+    z
+      .object({
+        /** Deprecated CSS rule strings applied by the plugin. */
+        css: z.array(z.string())
+      })
+      .passthrough()
+  ),
+  /** Response for `getDecoratedConfig`: fully resolved configuration after plugin decoration. */
   getDecoratedConfig: configOptionsSchema,
+  /** Response for `getDecoratedKeymaps`: keybinding action names to key combination strings. */
   getDecoratedKeymaps: z.record(z.string(), z.array(z.string())),
+  /** Response for `getRuntimePluginCommands`: commands registered by loaded plugins. */
   getRuntimePluginCommands: z.array(commandDefinitionSchema)
 } satisfies Record<keyof IpcCommands, ZodType>;

--- a/lib/types/request-shapes.ts
+++ b/lib/types/request-shapes.ts
@@ -1,3 +1,9 @@
 /** @file Shared request-shape types used across bootstrap and action layers. */
 
-export type SplitRequestParams = {activeUid?: string; profile?: string};
+/** Optional context for a new-session or split request. */
+export type SplitRequestParams = {
+  /** Session to split from, or use as the source of context, defaulting to the active session. */
+  activeUid?: string;
+  /** Profile to launch the new session with, defaulting to the source session's profile. */
+  profile?: string;
+};

--- a/lib/utils/clock.ts
+++ b/lib/utils/clock.ts
@@ -2,5 +2,6 @@
 
 /** Shared clock adapter for runtime code that needs current epoch milliseconds. */
 export const clock = {
+  /** Returns the current time in epoch milliseconds. */
   now: () => Date.now()
 };

--- a/lib/utils/config.ts
+++ b/lib/utils/config.ts
@@ -16,10 +16,12 @@ Object.defineProperty(window, 'profileName', {
   }
 });
 
+/** Returns the plugin-decorated config for the current window's profile. */
 export function getConfig() {
   return plugins.getDecoratedConfig(window.profileName);
 }
 
+/** Registers `fn` for config and plugin change IPC events, returning an unsubscribe function. */
 export function subscribe(fn: (event: Electron.IpcRendererEvent, ...args: any[]) => void) {
   ipcRenderer.on('config change', fn);
   ipcRenderer.on('plugins change', fn);

--- a/lib/utils/effects.ts
+++ b/lib/utils/effects.ts
@@ -21,6 +21,7 @@ const hasEffect = (action: unknown): action is HyperActions => {
   return 'effect' in action;
 };
 
+/** Middleware running action side effects after reducers have applied. */
 const effectsMiddleware: Middleware<{}, HyperState, Dispatch<HyperActions>> = () => (next) => (action) => {
   const ret = next(action);
   if (hasEffect(action) && typeof action.effect === 'function') {
@@ -32,4 +33,6 @@ const effectsMiddleware: Middleware<{}, HyperState, Dispatch<HyperActions>> = ()
   }
   return ret;
 };
+/** Redux middleware that runs each dispatched action's `effect` callback exactly once. */
+/** Middleware running action side effects after reducers have applied. */
 export default effectsMiddleware;

--- a/lib/utils/file.ts
+++ b/lib/utils/file.ts
@@ -13,6 +13,7 @@
 import fs from 'node:fs';
 import type {Stats} from 'node:fs';
 
+/** Reports whether the file described by `fileStat` is executable (always true on Windows). */
 export function isExecutable(fileStat: Stats): boolean {
   if (process.platform === 'win32') {
     return true;
@@ -21,6 +22,7 @@ export function isExecutable(fileStat: Stats): boolean {
   return Boolean(fileStat.mode & 0o0001 || fileStat.mode & 0o0010 || fileStat.mode & 0o0100);
 }
 
+/** Reads the file at `filePath` and resolves its contents as base64, or `null` on read failure. */
 export function getBase64FileData(filePath: string): Promise<string | null> {
   return new Promise((resolve): void => {
     return fs.readFile(filePath, (err, data) => {

--- a/lib/utils/ipc-child-process.ts
+++ b/lib/utils/ipc-child-process.ts
@@ -2,6 +2,7 @@ import type {ExecFileOptions, ExecOptions} from 'node:child_process';
 
 import {ipcRenderer} from './ipc';
 
+/** Runs a shell command in the main process via IPC and reports the result to `callback`. */
 export function exec(command: string, options: ExecOptions, callback: (..._args: any) => void) {
   if (typeof options === 'function') {
     callback = options;
@@ -13,10 +14,12 @@ export function exec(command: string, options: ExecOptions, callback: (..._args:
   );
 }
 
+/** Disabled in the renderer: synchronous child process execution must happen in the main process. */
 export function execSync() {
   console.error('Calling execSync from renderer is disabled');
 }
 
+/** Runs an executable in the main process via IPC and reports the result to `callback`. */
 export function execFile(file: string, args: string[], options: ExecFileOptions, callback: (..._args: any) => void) {
   if (typeof options === 'function') {
     callback = options;
@@ -33,30 +36,44 @@ export function execFile(file: string, args: string[], options: ExecFileOptions,
   );
 }
 
+/** Disabled in the renderer: synchronous file execution must happen in the main process. */
 export function execFileSync() {
   console.error('Calling execFileSync from renderer is disabled');
 }
 
+/** Disabled in the renderer: spawning processes must happen in the main process. */
 export function spawn() {
   console.error('Calling spawn from renderer is disabled');
 }
 
+/** Disabled in the renderer: synchronous process spawning must happen in the main process. */
 export function spawnSync() {
   console.error('Calling spawnSync from renderer is disabled');
 }
 
+/** Disabled in the renderer: forking processes must happen in the main process. */
 export function fork() {
   console.error('Calling fork from renderer is disabled');
 }
 
+/** Renderer-side child-process facade backed by IPC to the main process. */
 const IPCChildProcess = {
+  /** Runs a shell command in the main process via IPC and reports the result to `callback`. */
   exec,
+  /** Disabled in the renderer: synchronous child process execution must happen in the main process. */
   execSync,
+  /** Runs an executable in the main process via IPC and reports the result to `callback`. */
   execFile,
+  /** Disabled in the renderer: synchronous file execution must happen in the main process. */
   execFileSync,
+  /** Disabled in the renderer: spawning processes must happen in the main process. */
   spawn,
+  /** Disabled in the renderer: synchronous process spawning must happen in the main process. */
   spawnSync,
+  /** Disabled in the renderer: forking processes must happen in the main process. */
   fork
 };
 
+/** `child_process`-like API forwarding execution requests to the main process over IPC. */
+/** Renderer-side child-process facade backed by IPC to the main process. */
 export default IPCChildProcess;

--- a/lib/utils/ipc.ts
+++ b/lib/utils/ipc.ts
@@ -2,4 +2,5 @@ import {ipcRenderer as _ipc} from 'electron';
 
 import type {IpcRendererWithCommands} from '@shared/types/common';
 
+/** Electron's `ipcRenderer`, typed with the application's IPC command channels. */
 export const ipcRenderer = _ipc as IpcRendererWithCommands;

--- a/lib/utils/notify.ts
+++ b/lib/utils/notify.ts
@@ -1,4 +1,5 @@
 /* eslint no-new:0 */
+/** Logs and shows a desktop notification, also logging `details.error` when present. */
 export default function notify(title: string, body: string, details: {error?: any} = {}) {
   console.log(`[Notification] ${title}: ${body}`);
   if (details.error) {

--- a/lib/utils/object.ts
+++ b/lib/utils/object.ts
@@ -2,6 +2,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 const valsCache = new WeakMap();
 
+/** Returns (and caches by identity) the values of an object, for cheap repeated lookups on immutables. */
 export function values(imm: Record<string, any>) {
   if (!valsCache.has(imm)) {
     valsCache.set(imm, Object.values(imm));
@@ -10,6 +11,7 @@ export function values(imm: Record<string, any>) {
 }
 
 const keysCache = new WeakMap();
+/** Returns (and caches by identity) the keys of an object, for cheap repeated lookups on immutables. */
 export function keys(imm: Record<string, any>) {
   if (!keysCache.has(imm)) {
     keysCache.set(imm, Object.keys(imm));
@@ -17,6 +19,7 @@ export function keys(imm: Record<string, any>) {
   return keysCache.get(imm);
 }
 
+/** `Object.keys` typed to return `(keyof T)[]` instead of `string[]`. */
 export const ObjectTypedKeys = <T extends object>(obj: T) => {
   return Object.keys(obj) as (keyof T)[];
 };

--- a/lib/utils/pane-visibility.ts
+++ b/lib/utils/pane-visibility.ts
@@ -1,16 +1,24 @@
 /** @file Derives pane visibility from active-tab state, bounds, and occlusion. */
 
+/** Measured size of a pane's layout box. */
 export type PaneLayoutBounds = Readonly<{
+  /** Pane width in pixels. */
   width: number;
+  /** Pane height in pixels. */
   height: number;
 }>;
 
+/** Inputs used to decide whether a pane should currently be rendered. */
 export type PaneVisibilityInput = Readonly<{
+  /** Whether the pane's tab is the active tab. */
   isActiveTab: boolean;
+  /** The pane's current layout bounds, if measured. */
   bounds: PaneLayoutBounds | null | undefined;
+  /** Whether the pane is occluded (e.g. hidden behind another window or overlay). */
   isOccluded: boolean;
 }>;
 
+/** Reports whether `bounds` describes a non-zero, finite size that can actually be rendered. */
 export const hasRenderablePaneBounds = (bounds: PaneLayoutBounds | null | undefined) => {
   if (!bounds) {
     return false;
@@ -19,6 +27,7 @@ export const hasRenderablePaneBounds = (bounds: PaneLayoutBounds | null | undefi
   return Number.isFinite(bounds.width) && Number.isFinite(bounds.height) && bounds.width > 0 && bounds.height > 0;
 };
 
+/** Reports whether a pane is on the active tab, unoccluded, and has renderable bounds. */
 export const isPaneVisible = (input: PaneVisibilityInput) => {
   return input.isActiveTab && !input.isOccluded && hasRenderablePaneBounds(input.bounds);
 };

--- a/lib/utils/paste.ts
+++ b/lib/utils/paste.ts
@@ -25,6 +25,7 @@ const getPath = (platform: string) => {
   }
 };
 
+/** Returns file paths from the clipboard for drag-and-drop-style paste on macOS/Windows, else `null`. */
 export default function processClipboard() {
   return getPath(process.platform);
 }

--- a/lib/utils/plugins.ts
+++ b/lib/utils/plugins.ts
@@ -318,13 +318,20 @@ function getDecorated<P extends Record<string, any>>(
   return decorated[name];
 }
 
-// for each component, we return a higher-order component
-// that wraps with the higher-order components
-// exposed by plugins
+/**
+ * Returns a higher-order component that wraps `Component_` with the chain of higher-order
+ * components exposed by plugins for `name`, falling back to the undecorated component on crash.
+ */
 export function decorate<P extends Record<string, any>>(
   Component_: React.ComponentType<P>,
   name: string
-): React.ComponentClass<P, {hasError: boolean}> {
+): React.ComponentClass<
+  P,
+  {
+    /** Whether the decorated plugin chain has crashed and fallen back to the undecorated component. */
+    hasError: boolean;
+  }
+> {
   return class DecoratedComponent extends React.Component<P, {hasError: boolean}> {
     constructor(props: P) {
       super(props);
@@ -600,6 +607,7 @@ const loadModules = () => {
 // load modules for initial decoration
 loadModules();
 
+/** Clears cached plugin modules and require-cache entries, then reloads plugins from disk. */
 export function reload() {
   clearModulesCache();
   loadModules();
@@ -608,6 +616,7 @@ export function reload() {
   decorated = {};
 }
 
+/** Subscribes to tab decoration provider changes, returning an unsubscribe function. */
 export const subscribeTabDecorationUpdates = (listener: () => void) => {
   return subscribeTabDecorationProviderChanges(listener);
 };
@@ -644,6 +653,7 @@ function getProps(name: keyof typeof propsDecorators, props: any, ...fnArgs: any
   return props_ || props;
 }
 
+/** Applies each plugin's `getTermGroupProps` decorator in turn, returning the merged props. */
 export function getTermGroupProps<T extends Assignable<TermGroupOwnProps, T>>(
   uid: string,
   parentProps: any,
@@ -652,14 +662,17 @@ export function getTermGroupProps<T extends Assignable<TermGroupOwnProps, T>>(
   return getProps('getTermGroupProps', props, uid, parentProps);
 }
 
+/** Applies each plugin's `getTermProps` decorator in turn, returning the merged props. */
 export function getTermProps<T extends Assignable<TermProps, T>>(uid: string, parentProps: any, props: T): T {
   return getProps('getTermProps', props, uid, parentProps);
 }
 
+/** Applies each plugin's `getTabsProps` decorator in turn, returning the merged props. */
 export function getTabsProps<T extends Assignable<TabsProps, T>>(parentProps: any, props: T): T {
   return getProps('getTabsProps', props, parentProps);
 }
 
+/** Resolves the tab's decoration and applies each plugin's `getTabProps` decorator, merging the result. */
 export function getTabProps<T extends Assignable<TabProps, T>>(
   tab: TabLike,
   parentProps: ParentPropsLike,
@@ -678,9 +691,10 @@ export function getTabProps<T extends Assignable<TabProps, T>>(
   return getProps('getTabProps', decoratedProps, tab, parentProps);
 }
 
-// connects + decorates a class
-// plugins can override mapToState, dispatchToProps
-// and the class gets decorated (proxied)
+/**
+ * Connects and decorates a class, letting plugins override `mapToState`/`mapDispatchToProps`
+ * and wrap the resulting component.
+ */
 export function connect<StateProps extends Record<string, unknown>, DispatchProps extends Record<string, unknown>>(
   stateFn: (state: HyperState) => StateProps,
   dispatchFn: (dispatch: HyperDispatch) => DispatchProps,
@@ -791,19 +805,22 @@ const decorateReducer: {
   };
 };
 
+/** Wraps a term-groups reducer so registered plugin `reduceTermGroups` hooks run after it. */
 export function decorateTermGroupsReducer(fn: ITermGroupReducer) {
   return decorateReducer('reduceTermGroups', fn);
 }
 
+/** Wraps a UI reducer so registered plugin `reduceUI` hooks run after it. */
 export function decorateUIReducer(fn: IUiReducer) {
   return decorateReducer('reduceUI', fn);
 }
 
+/** Wraps a sessions reducer so registered plugin `reduceSessions` hooks run after it. */
 export function decorateSessionsReducer(fn: ISessionReducer) {
   return decorateReducer('reduceSessions', fn);
 }
 
-// redux middleware generator
+/** Redux middleware that chains together all plugin-registered middleware, in registration order. */
 export const middleware: Middleware<{}, HyperState, Dispatch<HyperActions>> = (store) => (next) => (action) => {
   const nextMiddleware = (remaining: Middleware[]) => (action_: any) =>
     remaining.length ? remaining[0](store)(nextMiddleware(remaining.slice(1)))(action_) : next(action_);

--- a/lib/utils/remote-plugins.ts
+++ b/lib/utils/remote-plugins.ts
@@ -7,6 +7,7 @@ import type {VelocettyRuntimeGlobals} from '../../typings/runtime-globals';
 
 export type {VelocettyRuntimeGlobals};
 
+/** Subset of the main-process plugins module's IPC commands used from the renderer. */
 export type RemotePluginsModule = Pick<
   IpcCommands,
   | 'getLoadedPluginVersions'
@@ -27,6 +28,7 @@ const getCandidatePluginModulePaths = (): string[] => {
   return Array.from(new Set(candidates));
 };
 
+/** Resolves and requires the main-process plugins module, trying each candidate path in turn. */
 export const loadRemotePluginsModule = () => {
   const candidates = getCandidatePluginModulePaths();
   let lastError: unknown;

--- a/lib/utils/rpc.ts
+++ b/lib/utils/rpc.ts
@@ -15,6 +15,7 @@ import type {
   TypedEmitter
 } from '@shared/types/common';
 
+/** Minimal `ipcRenderer` surface the RPC client needs to subscribe to and send messages. */
 export type RpcClientIpc = Pick<IpcRendererWithCommands, 'on' | 'removeListener' | 'send'>;
 
 type RpcWindowState = {
@@ -44,8 +45,11 @@ const resolveIpcRenderer = (): RpcClientIpc => {
 
 /** Renderer-side RPC client that forwards typed events over IPC. */
 export default class Client {
+  /** Local event emitter that renderer event listeners are attached to. */
   emitter: TypedEmitter<RendererEvents>;
+  /** The `ipcRenderer`-like transport used to send and receive IPC messages. */
   ipc: RpcClientIpc;
+  /** The window's RPC channel id, assigned once the main process signals readiness. */
   id!: string;
   private initListener?: InitListener;
 
@@ -101,25 +105,30 @@ export default class Client {
     return this.emitter.emit(ch as FilterNever<RendererEvents>, data as RendererEvents[FilterNever<RendererEvents>]);
   }
 
+  /** Decodes an IPC message envelope and re-emits it on the local emitter. */
   ipcListener = <U extends keyof RendererEvents>(
     _event: IpcRendererEvent,
     {ch, data}: {ch: U; data?: RendererEvents[U]}
   ) => this.emitRendererEvent(ch, data);
 
+  /** Registers a listener for a renderer event. */
   on = <U extends keyof RendererEvents>(ev: U, fn: (arg0: RendererEvents[U]) => void) => {
     this.emitter.on(ev, fn);
     return this;
   };
 
+  /** Alias of {@link removeListener}. */
   off = <U extends keyof RendererEvents>(ev: U, fn: (arg0: RendererEvents[U]) => void) => {
     return this.removeListener(ev, fn);
   };
 
+  /** Registers a one-shot listener for a renderer event. */
   once = <U extends keyof RendererEvents>(ev: U, fn: (arg0: RendererEvents[U]) => void) => {
     this.emitter.once(ev, fn);
     return this;
   };
 
+  /** Sends a typed command to the main process over IPC; throws if not yet ready. */
   emit<U extends Exclude<keyof MainEvents, FilterNever<MainEvents>>>(ev: U): boolean;
   emit<U extends FilterNever<MainEvents>>(ev: U, data: MainEvents[U]): boolean;
   emit<U extends keyof MainEvents>(ev: U, data?: MainEvents[U]) {
@@ -130,16 +139,19 @@ export default class Client {
     return true;
   }
 
+  /** Removes a previously registered listener for a renderer event. */
   removeListener = <U extends keyof RendererEvents>(ev: U, fn: (arg0: RendererEvents[U]) => void) => {
     this.emitter.removeListener(ev, fn);
     return this;
   };
 
+  /** Removes all listeners, or all listeners for a given event if specified. */
   removeAllListeners = <U extends keyof RendererEvents>(event?: U) => {
     this.emitter.removeAllListeners(event);
     return this;
   };
 
+  /** Tears down all listeners and detaches this client from its IPC channel. */
   destroy = () => {
     this.removeAllListeners();
     this.detachInitListener();

--- a/lib/utils/tab-decoration-providers.ts
+++ b/lib/utils/tab-decoration-providers.ts
@@ -17,9 +17,15 @@ declare const tabIdBrand: unique symbol;
 declare const tabDecorationProviderIdBrand: unique symbol;
 
 /** Branded identifier for tab-decoration context targets. */
-export type TabId = string & {[tabIdBrand]: 'TabId'};
+export type TabId = string & {
+  /** Nominal-typing brand; carries no runtime value. */
+  [tabIdBrand]: 'TabId';
+};
 /** Branded identifier for tab-decoration providers. */
-export type TabDecorationProviderId = string & {[tabDecorationProviderIdBrand]: 'TabDecorationProviderId'};
+export type TabDecorationProviderId = string & {
+  /** Nominal-typing brand; carries no runtime value. */
+  [tabDecorationProviderIdBrand]: 'TabDecorationProviderId';
+};
 
 /** Cast a raw tab identifier into the branded tab ID type. */
 export const asTabId = (value: string): TabId => value as TabId;
@@ -28,42 +34,68 @@ export const asTabDecorationProviderId = (value: string): TabDecorationProviderI
 
 /** Badge contribution shown alongside a tab label. */
 export type TabDecorationBadge = {
+  /** Short text shown on the badge. */
   text?: string;
+  /** Icon shown on the badge. */
   icon?: string;
+  /** Tooltip shown on hover. */
   tooltip?: string;
+  /** Severity styling for the badge. */
   kind?: 'info' | 'warn' | 'error';
 };
 
 /** Actionable widget contribution shown on a tab. */
 export type TabDecorationWidget = {
+  /** Icon shown for the widget. */
   icon: string;
+  /** Command invoked when the widget is activated. */
   command: CommandId;
+  /** Tooltip shown on hover. */
   tooltip?: string;
 };
 
 /** Combined decoration output for a single tab. */
 export type TabDecoration = {
-  icon?: {name: string; tooltip?: string};
+  /** Tab icon override, with its own tooltip. */
+  icon?: {
+    /** Icon name. */
+    name: string;
+    /** Tooltip shown on hover. */
+    tooltip?: string;
+  };
+  /** Tab title override. */
   title?: string;
+  /** Tab subtitle shown alongside the title. */
   subtitle?: string;
+  /** Badges to render on the tab, bounded and de-duplicated by the registry. */
   badges?: TabDecorationBadge[];
+  /** Widgets to render on the tab, bounded and de-duplicated by the registry. */
   widgets?: TabDecorationWidget[];
 };
 
 /** Runtime context passed to tab-decoration providers. */
 export type TabDecorationContext = {
+  /** Identifier of the tab being decorated. */
   tabId: TabId;
+  /** Index of the tab within its window. */
   tabIndex: number;
+  /** Whether the tab is the currently active tab. */
   active: boolean;
+  /** Whether the tab has unseen activity. */
   hasActivity: boolean;
+  /** Current tab title. */
   title?: string;
 };
 
 /** Contract for tab-decoration providers registered by plugins. */
 export type TabDecorationProvider = {
+  /** Unique identifier for the provider. */
   id: TabDecorationProviderId;
+  /** Higher-priority providers' decorations take precedence during merging. */
   priority: number;
+  /** Computes the decoration for a tab, or `null`/`undefined` to contribute nothing. */
   provideDecoration: (context: TabDecorationContext) => TabDecoration | null | undefined;
+  /** Optionally subscribes to change notifications, returning a disposer. */
   subscribe?: (onDidChange: () => void) => undefined | (() => void);
 };
 

--- a/lib/utils/term-groups.ts
+++ b/lib/utils/term-groups.ts
@@ -1,5 +1,6 @@
 import type {ITermState} from '../../typings/hyper';
 
+/** Finds the term group directly containing the given session, if any. */
 export default function findBySession(termGroupState: ITermState, sessionUid: string) {
   const {termGroups} = termGroupState;
   return Object.keys(termGroups)

--- a/lib/utils/webgl-context-pool.ts
+++ b/lib/utils/webgl-context-pool.ts
@@ -1,17 +1,26 @@
 /** @file Tracks WebGL context allocations with strict capacity and LRU eviction. */
 
+/** Configuration for a {@link WebGLContextPool}. */
 export type WebGLContextPoolOptions = Readonly<{
+  /** Maximum number of contexts the pool retains before evicting the least recently visible one. */
   maxContexts: number;
 }>;
 
+/** Creates a new WebGL context for a pool entry. */
 export type WebGLContextFactory<TContext> = () => TContext;
 
+/** Disposes of a WebGL context evicted or released from a pool. */
 export type WebGLContextDisposer<TContext> = (context: TContext, paneId: string) => void;
 
+/** Outcome of acquiring a context from a {@link WebGLContextPool}. */
 export type WebGLAcquireResult<TContext> = Readonly<{
+  /** The acquired (new or reused) context. */
   context: TContext;
+  /** Whether an existing context for the pane was reused rather than created. */
   reused: boolean;
+  /** Pane id evicted to make room, if any. */
   evictedPaneId: string | null;
+  /** Context evicted to make room, if any. */
   evictedContext: TContext | null;
 }>;
 
@@ -26,6 +35,7 @@ const assertValidMaxContexts = (maxContexts: number) => {
   }
 };
 
+/** Fixed-capacity pool of WebGL contexts keyed by pane id, evicting the least recently visible pane. */
 export class WebGLContextPool<TContext> {
   readonly #entries = new Map<string, WebGLPoolEntry<TContext>>();
   readonly #maxContexts: number;
@@ -36,22 +46,27 @@ export class WebGLContextPool<TContext> {
     this.#maxContexts = options.maxContexts;
   }
 
+  /** The pool's configured maximum context capacity. */
   get maxContexts() {
     return this.#maxContexts;
   }
 
+  /** The number of contexts currently held by the pool. */
   get size() {
     return this.#entries.size;
   }
 
+  /** Reports whether the pool currently holds a context for `paneId`. */
   has(paneId: string) {
     return this.#entries.has(paneId);
   }
 
+  /** Returns the context held for `paneId`, if any, without affecting its recency. */
   get(paneId: string) {
     return this.#entries.get(paneId)?.context;
   }
 
+  /** Returns the pane's context, or creates one, evicting the least recently visible pane if at capacity. */
   acquire(
     paneId: string,
     createContext: WebGLContextFactory<TContext>,
@@ -102,6 +117,7 @@ export class WebGLContextPool<TContext> {
     };
   }
 
+  /** Removes and returns the pane's context, disposing it via `disposeContext` if given. */
   release(paneId: string, disposeContext?: WebGLContextDisposer<TContext>) {
     const entry = this.#entries.get(paneId);
     if (!entry) {
@@ -113,6 +129,7 @@ export class WebGLContextPool<TContext> {
     return entry.context;
   }
 
+  /** Marks the pane's context as recently visible; reports whether an entry existed to touch. */
   touch(paneId: string) {
     const entry = this.#entries.get(paneId);
     if (!entry) {
@@ -123,6 +140,7 @@ export class WebGLContextPool<TContext> {
     return true;
   }
 
+  /** Removes all held contexts, disposing each via `disposeContext` if given. */
   clear(disposeContext?: WebGLContextDisposer<TContext>) {
     if (disposeContext) {
       for (const [paneId, entry] of this.#entries) {

--- a/lib/v8-snapshot-util.ts
+++ b/lib/v8-snapshot-util.ts
@@ -23,7 +23,9 @@ type SnapshotRuntimeEnvironment = {
   window?: SnapshotRuntimeWindow;
 };
 
+/** Handle returned by {@link bootstrapSnapshotRuntime} for undoing its module loader patch. */
 export type SnapshotBootstrapHandle = {
+  /** Restores the module loader to its pre-bootstrap state, once. */
   restore(): void;
 };
 
@@ -84,6 +86,10 @@ const rebuildSnapshotLoaderChain = (
   return nextLoad;
 };
 
+/**
+ * Wires the V8 snapshot's custom module loader into Node's `require`, so snapshotted modules
+ * are served from the snapshot cache instead of being re-required from disk.
+ */
 export const bootstrapSnapshotRuntime = (
   runtimeHost: SnapshotRuntimeEnvironment = globalThis as SnapshotRuntimeEnvironment
 ): SnapshotBootstrapHandle | null => {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "build:hyper-app": "bun ./build/esbuild/build.ts --mode=production --target=hyper-app",
     "lint": "bun node_modules/@biomejs/biome/bin/biome check . && bun run check:boundaries",
     "check:types": "bunx tsgo --project tsconfig.typecheck.json",
+    "docs:check": "typedoc --options typedoc.shared.json && typedoc --options typedoc.frontend.json && typedoc --options typedoc.backend.json && typedoc --options typedoc.app.json",
     "audit": "bun scripts/run-audit.mjs",
     "test": "bun run lint && bun run test:unit",
     "test:unit:run": "bun test --concurrent test/unit",
@@ -136,6 +137,7 @@
     "postcss": "^8.5.8",
     "prettier": "^3.2.5",
     "tailwindcss": "^4.2.2",
+    "typedoc": "^0.28.20",
     "typescript": "^5.4.5"
   },
   "overrides": {

--- a/shared/src/config/json5-config.ts
+++ b/shared/src/config/json5-config.ts
@@ -2,19 +2,37 @@
 import JSON5 from 'json5';
 import {z} from 'zod';
 
-export type ParseSuccess<T> = {success: true; data: T};
-export type ParseFailure = {success: false; error: Error};
+/** Outcome of a successful schema-validated parse. */
+export type ParseSuccess<T> = {
+  /** Discriminant confirming the parse succeeded. */
+  success: true;
+  /** The validated, typed payload. */
+  data: T;
+};
+/** Outcome of a failed schema-validated parse. */
+export type ParseFailure = {
+  /** Discriminant confirming the parse failed. */
+  success: false;
+  /** Reason the payload was rejected. */
+  error: Error;
+};
+/** Result of validating a value against a {@link ParseSchema}. */
 export type ParseResult<T> = ParseSuccess<T> | ParseFailure;
+/** Minimal schema contract this module needs from a validator (e.g. a Zod schema). */
 export type ParseSchema<T> = {
+  /** Validates an unknown value, returning a typed result rather than throwing. */
   readonly safeParse: (value: unknown) => ParseResult<T>;
 };
 
+/** Narrows to a plain object, excluding arrays and `null`, ahead of field-level checks. */
 export const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
 
+/** Narrows to an array whose every element is a string. */
 export const isStringArray = (value: unknown): value is string[] =>
   Array.isArray(value) && value.every((item) => typeof item === 'string');
 
+/** Narrows to a keymap map, whose values are either a single binding or a list of bindings. */
 export const isKeymapConfig = (value: unknown): value is Record<string, string | string[]> =>
   isRecord(value) && Object.values(value).every((entry) => typeof entry === 'string' || isStringArray(entry));
 
@@ -68,6 +86,11 @@ const validateFields = (value: Record<string, unknown>): Error | null => {
   return null;
 };
 
+/**
+ * Validates a raw config payload's shape, falling back to per-field checks so the
+ * error message pinpoints the offending property rather than dumping the raw
+ * Zod issue list.
+ */
 export const validateRawConfig = (value: unknown): ParseResult<Record<string, unknown>> => {
   const parsed = rawConfigSchema.safeParse(value);
   if (parsed.success) {
@@ -86,6 +109,7 @@ export const validateRawConfig = (value: unknown): ParseResult<Record<string, un
   return {success: false, error: parsed.error};
 };
 
+/** Recursively sorts object keys so serialized config output is stable and diff-friendly. */
 export const sortKeys = (value: unknown): unknown => {
   if (Array.isArray(value)) {
     return value.map((item) => sortKeys(item));
@@ -104,16 +128,24 @@ export const sortKeys = (value: unknown): unknown => {
   return value;
 };
 
+/** Inputs for a schema-validated, non-throwing JSON5 parse. */
 export interface ParseJson5Options<T> {
+  /** Raw JSON5 text to parse. */
   readonly raw: string;
+  /** Human-readable origin of the text, used in warning messages. */
   readonly source: string;
+  /** Schema used to validate the parsed payload. */
   readonly schema: ParseSchema<T>;
+  /** Value returned when parsing or validation fails. */
   readonly fallback: T;
+  /** Noun describing the payload kind, used in warning messages (defaults to `config`). */
   readonly itemType?: string;
 }
 
+/** Alias for {@link ParseJson5Options}. */
 export type ParseOptions<T> = ParseJson5Options<T>;
 
+/** Parses JSON5 against a schema, logging and falling back instead of throwing on failure. */
 export const parseJson5WithSchema = <T>(options: ParseJson5Options<T>): T => {
   const {raw, source, schema, fallback, itemType = 'config'} = options;
   try {
@@ -130,8 +162,10 @@ export const parseJson5WithSchema = <T>(options: ParseJson5Options<T>): T => {
   }
 };
 
+/** Parses JSON5 against a Zod schema, throwing on parse or validation failure. */
 export const parseJson5StrictWithSchema = <T>(raw: string, schema: z.ZodType<T>): T => {
   return schema.parse(JSON5.parse(raw) as unknown);
 };
 
+/** Serializes a value as pretty-printed JSON5 with keys sorted for stable diffs. */
 export const stringifyJson5 = (value: unknown): string => `${JSON5.stringify(sortKeys(value), null, 2)}\n`;

--- a/shared/src/constants/config.ts
+++ b/shared/src/constants/config.ts
@@ -8,15 +8,21 @@ export const CONFIG_RELOAD = 'CONFIG_RELOAD';
 
 /** Action contract for `CONFIG_LOAD` events. */
 export interface ConfigLoadAction {
+  /** Discriminates this action as `CONFIG_LOAD`. */
   readonly type: typeof CONFIG_LOAD;
+  /** Configuration options loaded from disk. */
   readonly config: configOptions;
+  /** Timestamp the load completed, when known. */
   readonly now?: number;
 }
 
 /** Action contract for `CONFIG_RELOAD` events. */
 export interface ConfigReloadAction {
+  /** Discriminates this action as `CONFIG_RELOAD`. */
   readonly type: typeof CONFIG_RELOAD;
+  /** Configuration options re-read from disk. */
   readonly config: configOptions;
+  /** Timestamp the reload completed. */
   readonly now: number;
 }
 

--- a/shared/src/constants/index.ts
+++ b/shared/src/constants/index.ts
@@ -8,6 +8,7 @@ export const INIT = 'INIT';
 
 /** Action contract for initialization events. */
 export interface InitAction {
+  /** Discriminates this action as `INIT`. */
   readonly type: typeof INIT;
 }
 

--- a/shared/src/constants/notifications.ts
+++ b/shared/src/constants/notifications.ts
@@ -6,15 +6,21 @@ export const NOTIFICATION_DISMISS = 'NOTIFICATION_DISMISS';
 
 /** Action contract for notification enqueue events. */
 export interface NotificationMessageAction {
+  /** Discriminates this action as `NOTIFICATION_MESSAGE`. */
   readonly type: typeof NOTIFICATION_MESSAGE;
+  /** Notification body text. */
   readonly text: string;
+  /** Optional link opened when the notification is activated. */
   readonly url: string | null;
+  /** Whether the user can dismiss the notification manually. */
   readonly dismissable: boolean;
 }
 
 /** Action contract for notification dismiss events. */
 export interface NotificationDismissAction {
+  /** Discriminates this action as `NOTIFICATION_DISMISS`. */
   readonly type: typeof NOTIFICATION_DISMISS;
+  /** Identifier of the notification to dismiss. */
   readonly id: string;
 }
 

--- a/shared/src/constants/runtime-telemetry.ts
+++ b/shared/src/constants/runtime-telemetry.ts
@@ -15,9 +15,11 @@ export const LONG_FRAME_THRESHOLD_MS = 16;
 /** Runtime metric reporting cadence from renderer to main process. */
 export const RUNTIME_METRICS_REPORT_INTERVAL_MS = 1000;
 
+/** Maximum number of pending input-send timestamps retained per session. */
 export const INPUT_SEND_TIMESTAMP_QUEUE_LIMIT = 128;
 const inputSendTimestampsByUid = new Map<RendererUid, number[]>();
 
+/** Returns the input-send timestamp queue for a session, creating it on first use. */
 export const getOrCreateTimestampQueue = (uid: RendererUid) => {
   const queue = inputSendTimestampsByUid.get(uid);
   if (queue) {

--- a/shared/src/constants/sessions.ts
+++ b/shared/src/constants/sessions.ts
@@ -1,107 +1,158 @@
 /** @file Shared session action constants and action contracts. */
 import type {ProfileId, SessionId} from '../types/common';
 
+/** Action type constant for adding a newly created session. */
 export const SESSION_ADD = 'SESSION_ADD';
+/** Action type constant for resizing a session's terminal viewport. */
 export const SESSION_RESIZE = 'SESSION_RESIZE';
+/** Action type constant for requesting a new session from the backend. */
 export const SESSION_REQUEST = 'SESSION_REQUEST';
+/** Action type constant marking that data is pending for a session. */
 export const SESSION_ADD_DATA = 'SESSION_ADD_DATA';
+/** Action type constant for appending PTY output to a session. */
 export const SESSION_PTY_DATA = 'SESSION_PTY_DATA';
+/** Action type constant for a backend-triggered PTY exit. */
 export const SESSION_PTY_EXIT = 'SESSION_PTY_EXIT';
+/** Action type constant for a user-triggered session exit. */
 export const SESSION_USER_EXIT = 'SESSION_USER_EXIT';
+/** Action type constant for marking a session as active. */
 export const SESSION_SET_ACTIVE = 'SESSION_SET_ACTIVE';
+/** Action type constant for clearing the active session reference. */
 export const SESSION_CLEAR_ACTIVE = 'SESSION_CLEAR_ACTIVE';
+/** Action type constant for recording user data updates to session metadata. */
 export const SESSION_USER_DATA = 'SESSION_USER_DATA';
+/** Action type constant for updating a session's xterm title. */
 export const SESSION_SET_XTERM_TITLE = 'SESSION_SET_XTERM_TITLE';
+/** Action type constant for updating a session's reported working directory. */
 export const SESSION_SET_CWD = 'SESSION_SET_CWD';
+/** Action type constant for toggling a session's search UI visibility. */
 export const SESSION_SEARCH = 'SESSION_SEARCH';
 
 /** Adds a newly created session to state. */
 export interface SessionAddAction {
+  /** Discriminates this action as `SESSION_ADD`. */
   readonly type: typeof SESSION_ADD;
+  /** Identifier of the session being added. */
   readonly uid: SessionId;
+  /** Shell command launched for the session, if known. */
   readonly shell: string | null;
+  /** Process ID of the spawned shell, if known. */
   readonly pid: number | null;
+  /** Initial terminal column count, if known. */
   readonly cols: number | null;
+  /** Initial terminal row count, if known. */
   readonly rows: number | null;
+  /** Pane split orientation when the session was created via a split. */
   readonly splitDirection?: 'HORIZONTAL' | 'VERTICAL';
+  /** Session that should remain active after this one is added. */
   readonly activeUid: SessionId | null;
+  /** Timestamp the session was added. */
   readonly now: number;
+  /** Profile used to configure the session. */
   readonly profile: ProfileId;
 }
 
 /** Resizes an existing session terminal viewport. */
 export interface SessionResizeAction {
+  /** Discriminates this action as `SESSION_RESIZE`. */
   readonly type: typeof SESSION_RESIZE;
+  /** Identifier of the session being resized. */
   readonly uid: SessionId;
+  /** New terminal column count. */
   readonly cols: number;
+  /** New terminal row count. */
   readonly rows: number;
+  /** Whether the resize targets a standalone (non-tabbed) terminal window. */
   readonly isStandaloneTerm: boolean;
+  /** Timestamp the resize occurred. */
   readonly now: number;
 }
 
 /** Requests a new session from the backend. */
 export interface SessionRequestAction {
+  /** Discriminates this action as `SESSION_REQUEST`. */
   readonly type: typeof SESSION_REQUEST;
 }
 
 /** Marks that data is pending for a session. */
 export interface SessionAddDataAction {
+  /** Discriminates this action as `SESSION_ADD_DATA`. */
   readonly type: typeof SESSION_ADD_DATA;
 }
 
 /** Appends PTY data for a session. */
 export interface SessionPtyDataAction {
+  /** Discriminates this action as `SESSION_PTY_DATA`. */
   readonly type: typeof SESSION_PTY_DATA;
+  /** Raw PTY output chunk. */
   readonly data: string;
+  /** Identifier of the session the data belongs to. */
   readonly uid: SessionId;
+  /** Timestamp the data was received. */
   readonly now: number;
 }
 
 /** Handles backend PTY exit events for a session. */
 export interface SessionPtyExitAction {
+  /** Discriminates this action as `SESSION_PTY_EXIT`. */
   readonly type: typeof SESSION_PTY_EXIT;
+  /** Identifier of the session whose PTY exited. */
   readonly uid: SessionId;
 }
 
 /** Handles user-triggered session exits. */
 export interface SessionUserExitAction {
+  /** Discriminates this action as `SESSION_USER_EXIT`. */
   readonly type: typeof SESSION_USER_EXIT;
+  /** Identifier of the session being closed. */
   readonly uid: SessionId;
 }
 
 /** Marks a specific session as active. */
 export interface SessionSetActiveAction {
+  /** Discriminates this action as `SESSION_SET_ACTIVE`. */
   readonly type: typeof SESSION_SET_ACTIVE;
+  /** Identifier of the session to make active. */
   readonly uid: SessionId;
 }
 
 /** Clears the currently active session reference. */
 export interface SessionClearActiveAction {
+  /** Discriminates this action as `SESSION_CLEAR_ACTIVE`. */
   readonly type: typeof SESSION_CLEAR_ACTIVE;
 }
 
 /** Records user data updates for session metadata. */
 export interface SessionUserDataAction {
+  /** Discriminates this action as `SESSION_USER_DATA`. */
   readonly type: typeof SESSION_USER_DATA;
 }
 
 /** Updates the xterm title for a session. */
 export interface SessionSetXtermTitleAction {
+  /** Discriminates this action as `SESSION_SET_XTERM_TITLE`. */
   readonly type: typeof SESSION_SET_XTERM_TITLE;
+  /** Identifier of the session whose title changed. */
   readonly uid: SessionId;
+  /** New xterm title reported by the shell. */
   readonly title: string;
 }
 
 /** Updates the working directory shown for a session. */
 export interface SessionSetCwdAction {
+  /** Discriminates this action as `SESSION_SET_CWD`. */
   readonly type: typeof SESSION_SET_CWD;
+  /** New working directory reported for the session. */
   readonly cwd: string;
 }
 
 /** Toggles search UI visibility for a session. */
 export interface SessionSearchAction {
+  /** Discriminates this action as `SESSION_SEARCH`. */
   readonly type: typeof SESSION_SEARCH;
+  /** Identifier of the session the search UI applies to. */
   readonly uid: SessionId;
+  /** Whether the search UI should be shown. */
   readonly value: boolean;
 }
 

--- a/shared/src/constants/tabs.ts
+++ b/shared/src/constants/tabs.ts
@@ -6,11 +6,13 @@ export const CHANGE_TAB = 'CHANGE_TAB';
 
 /** Action contract for close-tab events. */
 export interface CloseTabAction {
+  /** Discriminates this action as `CLOSE_TAB`. */
   readonly type: typeof CLOSE_TAB;
 }
 
 /** Action contract for change-tab events. */
 export interface ChangeTabAction {
+  /** Discriminates this action as `CHANGE_TAB`. */
   readonly type: typeof CHANGE_TAB;
 }
 

--- a/shared/src/constants/term-groups.ts
+++ b/shared/src/constants/term-groups.ts
@@ -1,37 +1,50 @@
 /** @file Shared terminal group action constants and action contracts. */
 import type {TermGroupId} from '../types/common';
 
+/** Action type constant for requesting a new terminal group. */
 export const TERM_GROUP_REQUEST = 'TERM_GROUP_REQUEST';
+/** Action type constant for exiting a specified terminal group. */
 export const TERM_GROUP_EXIT = 'TERM_GROUP_EXIT';
+/** Action type constant for resizing panes within a terminal group. */
 export const TERM_GROUP_RESIZE = 'TERM_GROUP_RESIZE';
+/** Action type constant for exiting the currently active terminal group. */
 export const TERM_GROUP_EXIT_ACTIVE = 'TERM_GROUP_EXIT_ACTIVE';
 
 /** Split orientation for terminal groups. */
 export enum DIRECTION {
+  /** Panes are arranged side by side. */
   HORIZONTAL = 'HORIZONTAL',
+  /** Panes are stacked top to bottom. */
   VERTICAL = 'VERTICAL'
 }
 
 /** Requests a new terminal group. */
 export interface TermGroupRequestAction {
+  /** Discriminates this action as `TERM_GROUP_REQUEST`. */
   readonly type: typeof TERM_GROUP_REQUEST;
 }
 
 /** Exits the specified terminal group. */
 export interface TermGroupExitAction {
+  /** Discriminates this action as `TERM_GROUP_EXIT`. */
   readonly type: typeof TERM_GROUP_EXIT;
+  /** Identifier of the terminal group to exit. */
   readonly uid: TermGroupId;
 }
 
 /** Resizes panes in a terminal group. */
 export interface TermGroupResizeAction {
+  /** Discriminates this action as `TERM_GROUP_RESIZE`. */
   readonly type: typeof TERM_GROUP_RESIZE;
+  /** Identifier of the terminal group being resized. */
   readonly uid: TermGroupId;
+  /** New pane sizes, in split order. */
   readonly sizes: number[];
 }
 
 /** Exits the currently active terminal group. */
 export interface TermGroupExitActiveAction {
+  /** Discriminates this action as `TERM_GROUP_EXIT_ACTIVE`. */
   readonly type: typeof TERM_GROUP_EXIT_ACTIVE;
 }
 

--- a/shared/src/constants/ui.ts
+++ b/shared/src/constants/ui.ts
@@ -52,125 +52,153 @@ export const UI_COMMAND_EXEC = 'UI_COMMAND_EXEC';
 
 /** Action contract for setting font size directly. */
 export interface UIFontSizeSetAction {
+  /** Discriminates this action as `UI_FONT_SIZE_SET`. */
   readonly type: typeof UI_FONT_SIZE_SET;
+  /** Font size, in points, to apply. */
   readonly value: number;
 }
 
 /** Action contract for increasing font size. */
 export interface UIFontSizeIncrAction {
+  /** Discriminates this action as `UI_FONT_SIZE_INCR`. */
   readonly type: typeof UI_FONT_SIZE_INCR;
 }
 
 /** Action contract for decreasing font size. */
 export interface UIFontSizeDecrAction {
+  /** Discriminates this action as `UI_FONT_SIZE_DECR`. */
   readonly type: typeof UI_FONT_SIZE_DECR;
 }
 
 /** Action contract for resetting font size. */
 export interface UIFontSizeResetAction {
+  /** Discriminates this action as `UI_FONT_SIZE_RESET`. */
   readonly type: typeof UI_FONT_SIZE_RESET;
 }
 
 /** Action contract for setting font smoothing. */
 export interface UIFontSmoothingSetAction {
+  /** Discriminates this action as `UI_FONT_SMOOTHING_SET`. */
   readonly type: typeof UI_FONT_SMOOTHING_SET;
+  /** Font smoothing mode to apply. */
   readonly fontSmoothing: string;
 }
 
 /** Action contract for moving left. */
 export interface UIMoveLeftAction {
+  /** Discriminates this action as `UI_MOVE_LEFT`. */
   readonly type: typeof UI_MOVE_LEFT;
 }
 
 /** Action contract for moving right. */
 export interface UIMoveRightAction {
+  /** Discriminates this action as `UI_MOVE_RIGHT`. */
   readonly type: typeof UI_MOVE_RIGHT;
 }
 
 /** Action contract for moving to a tab index. */
 export interface UIMoveToAction {
+  /** Discriminates this action as `UI_MOVE_TO`. */
   readonly type: typeof UI_MOVE_TO;
 }
 
 /** Action contract for focusing the next pane. */
 export interface UIMoveNextPaneAction {
+  /** Discriminates this action as `UI_MOVE_NEXT_PANE`. */
   readonly type: typeof UI_MOVE_NEXT_PANE;
 }
 
 /** Action contract for focusing the previous pane. */
 export interface UIMovePrevPaneAction {
+  /** Discriminates this action as `UI_MOVE_PREV_PANE`. */
   readonly type: typeof UI_MOVE_PREV_PANE;
 }
 
 /** Action contract for opening preferences. */
 export interface UIShowPreferencesAction {
+  /** Discriminates this action as `UI_SHOW_PREFERENCES`. */
   readonly type: typeof UI_SHOW_PREFERENCES;
 }
 
 /** Action contract for moving the window. */
 export interface UIWindowMoveAction {
+  /** Discriminates this action as `UI_WINDOW_MOVE`. */
   readonly type: typeof UI_WINDOW_MOVE;
 }
 
 /** Action contract for maximizing the window. */
 export interface UIWindowMaximizeAction {
+  /** Discriminates this action as `UI_WINDOW_MAXIMIZE`. */
   readonly type: typeof UI_WINDOW_MAXIMIZE;
 }
 
 /** Action contract for unmaximizing the window. */
 export interface UIWindowUnmaximizeAction {
+  /** Discriminates this action as `UI_WINDOW_UNMAXIMIZE`. */
   readonly type: typeof UI_WINDOW_UNMAXIMIZE;
 }
 
 /** Action contract for window geometry updates. */
 export interface UIWindowGeometryChangedAction {
+  /** Discriminates this action as `UI_WINDOW_GEOMETRY_CHANGED`. */
   readonly type: typeof UI_WINDOW_GEOMETRY_CHANGED;
+  /** Whether the window is currently maximized. */
   readonly isMaximized: boolean;
 }
 
 /** Action contract for opening a file. */
 export interface UIOpenFileAction {
+  /** Discriminates this action as `UI_OPEN_FILE`. */
   readonly type: typeof UI_OPEN_FILE;
 }
 
 /** Action contract for opening an SSH URL. */
 export interface UIOpenSshUrlAction {
+  /** Discriminates this action as `UI_OPEN_SSH_URL`. */
   readonly type: typeof UI_OPEN_SSH_URL;
 }
 
 /** Action contract for opening the hamburger menu. */
 export interface UIOpenHamburgerMenuAction {
+  /** Discriminates this action as `UI_OPEN_HAMBURGER_MENU`. */
   readonly type: typeof UI_OPEN_HAMBURGER_MENU;
 }
 
 /** Action contract for minimizing the window. */
 export interface UIWindowMinimizeAction {
+  /** Discriminates this action as `UI_WINDOW_MINIMIZE`. */
   readonly type: typeof UI_WINDOW_MINIMIZE;
 }
 
 /** Action contract for closing the window. */
 export interface UIWindowCloseAction {
+  /** Discriminates this action as `UI_WINDOW_CLOSE`. */
   readonly type: typeof UI_WINDOW_CLOSE;
 }
 
 /** Action contract for entering fullscreen mode. */
 export interface UIEnterFullscreenAction {
+  /** Discriminates this action as `UI_ENTER_FULLSCREEN`. */
   readonly type: typeof UI_ENTER_FULLSCREEN;
 }
 
 /** Action contract for leaving fullscreen mode. */
 export interface UILeaveFullscreenAction {
+  /** Discriminates this action as `UI_LEAVE_FULLSCREEN`. */
   readonly type: typeof UI_LEAVE_FULLSCREEN;
 }
 
 /** Action contract for opening context menus. */
 export interface UIContextmenuOpenAction {
+  /** Discriminates this action as `UI_CONTEXTMENU_OPEN`. */
   readonly type: typeof UI_CONTEXTMENU_OPEN;
 }
 
 /** Action contract for executing command palette actions. */
 export interface UICommandExecAction {
+  /** Discriminates this action as `UI_COMMAND_EXEC`. */
   readonly type: typeof UI_COMMAND_EXEC;
+  /** Identifier of the command to execute. */
   readonly command: CommandId;
 }
 

--- a/shared/src/constants/updater.ts
+++ b/shared/src/constants/updater.ts
@@ -11,15 +11,21 @@ export const UPDATE_AVAILABLE = 'UPDATE_AVAILABLE';
 
 /** Action contract for install-update events. */
 export interface UpdateInstallAction {
+  /** Discriminates this action as `UPDATE_INSTALL`. */
   readonly type: typeof UPDATE_INSTALL;
 }
 
 /** Action contract for update-available events. */
 export interface UpdateAvailableAction {
+  /** Discriminates this action as `UPDATE_AVAILABLE`. */
   readonly type: typeof UPDATE_AVAILABLE;
+  /** Version string of the available update. */
   readonly version: string;
+  /** Release notes for the update, if provided. */
   readonly notes: string | null;
+  /** URL of the release page for the update. */
   readonly releaseUrl: string;
+  /** Whether the update can be installed automatically. */
   readonly canInstall: boolean;
 }
 

--- a/shared/src/runtime/golden-path-demo.ts
+++ b/shared/src/runtime/golden-path-demo.ts
@@ -10,8 +10,11 @@ export const GOLDEN_PATH_KEYBINDING = 'ctrl+alt+shift+g';
 
 /** Settings payload persisted under `config.plugins[pluginId]`. */
 export type GoldenPathPluginSettings = {
+  /** Whether the plugin's command and keybinding contributions are active. */
   readonly enabled: boolean;
+  /** Notification text emitted when the plugin command is invoked. */
   readonly message: string;
+  /** Prefix rendered by the tab decoration provider for each tab title. */
   readonly tabPrefix: string;
 };
 
@@ -22,26 +25,43 @@ export const goldenPathSettingsDefaults: GoldenPathPluginSettings = {
   tabPrefix: 'GP'
 };
 
-/** JSON-schema-compatible settings descriptor used by the plugin manifest. */
+/**
+ * JSON-schema-compatible settings descriptor used by the plugin manifest; a
+ * data seam whose nested nodes carry their own `description` semantics.
+ *
+ * @internal
+ */
 export const goldenPathSettingsSchema = {
+  /** Schema node kind: this describes an object. */
   type: 'object',
+  /** Rejects settings payloads carrying keys outside those declared below. */
   additionalProperties: false,
+  /** JSON Schema definitions for each settings key. */
   properties: {
     enabled: {
+      /** Schema node kind for `enabled`: a boolean flag. */
       type: 'boolean',
+      /** Description surfaced to settings UI consumers. */
       description: 'Controls whether runtime command and keybinding contributions are active.'
     },
     message: {
+      /** Schema node kind for `message`: a string value. */
       type: 'string',
+      /** Minimum permitted string length. */
       minLength: 1,
+      /** Description surfaced to settings UI consumers. */
       description: 'Notification text emitted when the plugin command is invoked.'
     },
     tabPrefix: {
+      /** Schema node kind for `tabPrefix`: a string value. */
       type: 'string',
+      /** Minimum permitted string length. */
       minLength: 1,
+      /** Description surfaced to settings UI consumers. */
       description: 'Prefix rendered by the tab decoration provider for each tab title.'
     }
   },
+  /** Settings keys that must be present for the schema to validate. */
   required: ['enabled', 'message', 'tabPrefix']
 } as const;
 
@@ -59,38 +79,59 @@ export const goldenPathCommandDefinition: CommandDefinition = {
 
 /** Shared tab decoration shape returned by runtime plugin providers. */
 export type RuntimeTabDecorationBadge = {
+  /** Badge label text, if any. */
   readonly text?: string;
+  /** Badge icon identifier, if any. */
   readonly icon?: string;
+  /** Tooltip shown on hover, if any. */
   readonly tooltip?: string;
+  /** Severity styling applied to the badge. */
   readonly kind?: 'info' | 'warn' | 'error';
 };
 
+/** Clickable icon control rendered alongside a tab decoration. */
 export type RuntimeTabDecorationWidget = {
+  /** Icon identifier rendered for the widget. */
   readonly icon: string;
+  /** Command invoked when the widget is activated. */
   readonly command: CommandId;
+  /** Tooltip shown on hover, if any. */
   readonly tooltip?: string;
 };
 
+/** Decoration a tab decoration provider may apply to a single tab. */
 export type RuntimeTabDecoration = {
+  /** Replacement tab title, if any. */
   readonly title?: string;
+  /** Secondary text shown beneath the tab title, if any. */
   readonly subtitle?: string;
+  /** Status badges to render on the tab, if any. */
   readonly badges?: readonly RuntimeTabDecorationBadge[];
+  /** Interactive widgets to render on the tab, if any. */
   readonly widgets?: readonly RuntimeTabDecorationWidget[];
 };
 
 /** Context passed to runtime tab decoration providers. */
 export type RuntimeTabDecorationContext = {
+  /** Identifier of the tab being decorated. */
   readonly tabId: string;
+  /** Zero-based position of the tab. */
   readonly tabIndex: number;
+  /** Whether the tab is currently focused. */
   readonly active: boolean;
+  /** Whether the tab has unread activity. */
   readonly hasActivity: boolean;
+  /** Current tab title, if set. */
   readonly title?: string;
 };
 
 /** Runtime tab decoration provider contribution contract. */
 export type RuntimeTabDecorationProvider = {
+  /** Unique identifier for the provider. */
   readonly id: string;
+  /** Ordering weight; higher values take precedence when providers conflict. */
   readonly priority: number;
+  /** Computes the decoration to apply for a given tab, or `null`/`undefined` for none. */
   readonly provideDecoration: (
     context: RuntimeTabDecorationContext,
     settings: Record<string, unknown>
@@ -99,14 +140,23 @@ export type RuntimeTabDecorationProvider = {
 
 /** Runtime plugin manifest contract for roadmap 1.3.1 contributions. */
 export type RuntimePluginManifest = {
+  /** Stable plugin identifier used for namespaced settings persistence. */
   readonly id: string;
+  /** Plugin version string. */
   readonly version: string;
+  /** Human-readable plugin name shown in the UI. */
   readonly displayName: string;
+  /** Human-readable summary of what the plugin does. */
   readonly description: string;
+  /** JSON-schema-compatible descriptor for the plugin's settings shape. */
   readonly settingsSchema: Readonly<Record<string, unknown>>;
+  /** Default values applied when settings are not otherwise configured. */
   readonly settingsDefaults: Readonly<Record<string, unknown>>;
+  /** Commands the plugin registers with the command runtime. */
   readonly commands: readonly CommandDefinition[];
+  /** Default keybindings, keyed by command ID. */
   readonly keybindings: Readonly<Record<string, readonly string[]>>;
+  /** Tab decoration providers the plugin contributes. */
   readonly tabDecorationProviders: readonly RuntimeTabDecorationProvider[];
 };
 

--- a/shared/src/types/commands.ts
+++ b/shared/src/types/commands.ts
@@ -2,7 +2,11 @@
 
 /** Stable identifier used across keymaps, menus, dispatchers, and handlers. */
 declare const commandIdBrand: unique symbol;
-export type CommandId = string & {[commandIdBrand]: 'CommandId'};
+/** Branded string uniquely identifying a registered command. */
+export type CommandId = string & {
+  /** Phantom brand distinguishing a validated command id from a plain string; absent at runtime. */
+  [commandIdBrand]: 'CommandId';
+};
 /** Execution location for a command handler. */
 export type CommandKind = 'frontend' | 'backend';
 
@@ -11,34 +15,51 @@ declare const commandSchemaPayload: unique symbol;
 /** JSON Schema payload used to validate command arguments and results. */
 export type CommandSchema<TPayload = unknown> = {
   [key: string]: unknown;
+  /** Phantom carrier for the validated payload's TypeScript type; not present at runtime. */
   [commandSchemaPayload]?: TPayload;
 };
 
 /** UI-facing metadata that makes commands discoverable and explainable. */
 export interface CommandMetadata {
+  /** Label shown for the command in palettes, menus, and keymap editors. */
   title: string;
+  /** Grouping used to cluster related commands in the palette. */
   category?: string;
+  /** Longer explanation shown as help text or a tooltip. */
   description?: string;
+  /** Extra search terms so the command surfaces under related phrasing. */
   keywords?: string[];
+  /** Icon identifier rendered alongside the title in the palette/menu. */
   icon?: string;
 }
 
 /** Command contract shared between frontend and backend registries. */
 export interface CommandDefinition<TArgs = unknown, TResult = unknown> {
+  /** Unique key under which the command is registered and dispatched. */
   id: CommandId;
+  /** Palette/menu presentation details for the command. */
   metadata: CommandMetadata;
+  /** Which process owns execution, so dispatch can route the invocation correctly. */
   kind: CommandKind;
+  /** Default `when` expression gating whether the command is currently enabled. */
   defaultWhen?: string;
+  /** Schema used to validate arguments before the handler runs. */
   argsSchema?: CommandSchema<TArgs>;
+  /** Schema used to validate the handler's return value. */
   resultSchema?: CommandSchema<TResult>;
 }
 
 /** Location of a validation failure within a payload/schema pair. */
 export interface CommandValidationIssue {
+  /** JSON Pointer to the offending value within the validated payload. */
   instancePath: string;
+  /** JSON Pointer to the schema rule that rejected the value. */
   schemaPath: string;
+  /** Name of the failed schema rule (e.g. `required`, `type`). */
   keyword: string;
+  /** Human-readable explanation of the failure, when the validator supplies one. */
   message?: string;
+  /** Rule-specific detail (e.g. allowed values) attached by the validator. */
   params?: Record<string, unknown>;
 }
 
@@ -53,22 +74,31 @@ export type CommandValidationErrorCode =
 
 /** Structured validation error used by registry validation APIs. */
 export interface CommandValidationError {
+  /** Machine-readable classification for handling or logging the failure. */
   code: CommandValidationErrorCode;
+  /** Command whose validation failed. */
   commandId: CommandId;
+  /** Whether the failure was on the arguments or the result payload. */
   target?: CommandValidationTarget;
+  /** Human-readable summary of the failure. */
   message: string;
+  /** Detailed per-field validation issues, when the schema validator reports them. */
   issues?: CommandValidationIssue[];
 }
 
 /** Validation success payload for schema checks. */
 export interface CommandValidationSuccess<TValue = unknown> {
+  /** Discriminant marking this branch as the successful outcome. */
   ok: true;
+  /** Validated (and possibly coerced) payload, when the validator returns one. */
   value?: TValue;
 }
 
 /** Validation failure payload for schema checks. */
 export interface CommandValidationFailure {
+  /** Discriminant marking this branch as the failed outcome. */
   ok: false;
+  /** Details of why validation failed. */
   error: CommandValidationError;
 }
 
@@ -83,11 +113,18 @@ export type CommandOrderingComparator<TCommand extends Pick<CommandDefinition, '
 
 /** CRUD and validation contract shared by command registries. */
 export interface CommandRegistry<THandler = unknown> {
+  /** Adds a new command definition (and optional handler) to the registry. */
   register(definition: CommandDefinition, handler?: THandler): void;
+  /** Replaces an existing command's definition and/or handler in place. */
   update(definition: CommandDefinition, handler?: THandler): void;
+  /** Removes a command from the registry; returns whether it was present. */
   remove(commandId: CommandId): boolean;
+  /** Looks up a command's definition by id. */
   get(commandId: CommandId): CommandDefinition | undefined;
+  /** Returns all currently registered command definitions. */
   list(): CommandDefinition[];
+  /** Reports whether a command id is currently registered. */
   has(commandId: CommandId): boolean;
+  /** Validates candidate arguments for a command against its argsSchema. */
   validateArgs(commandId: CommandId, args: unknown): CommandValidationResult;
 }

--- a/shared/src/types/common.ts
+++ b/shared/src/types/common.ts
@@ -9,13 +9,25 @@ import type {CommandDefinition, CommandId} from './commands';
 import type {configOptions} from './config';
 
 /** Branded identifier for session entities. */
-export type SessionId = string & {readonly brand: 'SessionId'};
+export type SessionId = string & {
+  /** Phantom brand distinguishing a session id from a plain string; absent at runtime. */
+  readonly brand: 'SessionId';
+};
 /** Branded identifier for terminal profile names. */
-export type ProfileId = string & {readonly brand: 'ProfileId'};
+export type ProfileId = string & {
+  /** Phantom brand distinguishing a profile id from a plain string; absent at runtime. */
+  readonly brand: 'ProfileId';
+};
 /** Branded identifier for terminal group entities. */
-export type TermGroupId = string & {readonly brand: 'TermGroupId'};
+export type TermGroupId = string & {
+  /** Phantom brand distinguishing a terminal-group id from a plain string; absent at runtime. */
+  readonly brand: 'TermGroupId';
+};
 /** Branded identifier for renderer telemetry subjects. */
-export type RendererUid = string & {readonly brand: 'RendererUid'};
+export type RendererUid = string & {
+  /** Phantom brand distinguishing a renderer uid from a plain string; absent at runtime. */
+  readonly brand: 'RendererUid';
+};
 /** Renderer backends supported by runtime telemetry reporting. */
 export type RendererType = 'WebGL' | 'Canvas' | 'DOM';
 
@@ -30,26 +42,43 @@ export const asRendererUid = (uid: string): RendererUid => uid as RendererUid;
 
 /** Session state synchronized between backend and renderer layers. */
 export type Session = {
+  /** Identifier used to route IPC events and commands to this session. */
   uid: SessionId;
+  /** Terminal row count as last reported by the renderer, or unknown. */
   rows?: number | null;
+  /** Terminal column count as last reported by the renderer, or unknown. */
   cols?: number | null;
+  /** Pane split orientation, if this session was created as a split. */
   splitDirection?: 'HORIZONTAL' | 'VERTICAL';
+  /** Resolved shell binary path, or `null` before the process has spawned. */
   shell: string | null;
+  /** OS process id of the shell, or `null` before the process has spawned. */
   pid: number | null;
+  /** Sibling session that was active when this one was created via split. */
   activeUid?: SessionId;
+  /** Terminal profile this session was launched from. */
   profile: ProfileId;
 };
 
 /** Optional arguments accepted when creating or splitting sessions. */
 export type sessionExtraOptions = {
+  /** Working directory to spawn the shell in, overriding the profile default. */
   cwd?: string;
+  /** Orientation to split the pane in, when creating a split rather than a fresh tab. */
   splitDirection?: 'HORIZONTAL' | 'VERTICAL';
+  /** Session the new one is being split from, used to size and position the pane. */
   activeUid?: SessionId | null;
+  /** Whether this session should start a new terminal group (tab) rather than join one. */
   isNewGroup?: boolean;
+  /** Initial terminal row count. */
   rows?: number;
+  /** Initial terminal column count. */
   cols?: number;
+  /** Shell binary to launch, overriding the profile default. */
   shell?: string;
+  /** Arguments passed to the shell binary, overriding the profile default. */
   shellArgs?: string[];
+  /** Terminal profile to launch the session from. */
   profile?: ProfileId;
 };
 
@@ -58,98 +87,255 @@ export type RendererFallbackReason = 'context-loss' | 'pool-evicted' | 'webgl-in
 
 /** Rolling latency summary used by runtime diagnostics ingestion. */
 export type RuntimeLatencyMetrics = {
+  /** Number of latency samples aggregated into this window. */
   sampleCount: number;
+  /** Sum of all sampled latencies, used to derive an average. */
   totalMs: number;
+  /** Largest latency observed in this window. */
   maxMs: number;
+  /** Most recently observed latency. */
   lastMs: number;
 };
 
 /** Rolling frame-timing summary used by runtime diagnostics ingestion. */
 export type RuntimeFrameTimingMetrics = {
+  /** Number of frame samples aggregated into this window. */
   sampleCount: number;
+  /** Sum of all sampled frame durations, used to derive an average. */
   totalMs: number;
+  /** Longest frame duration observed in this window. */
   maxMs: number;
+  /** Most recently observed frame duration. */
   lastMs: number;
+  /** Count of frames that exceeded longFrameThresholdMs, indicating jank. */
   longFrameCount: number;
+  /** Duration above which a frame is counted as "long" (janky). */
   longFrameThresholdMs: number;
 };
 
 /** Runtime metrics emitted from renderer and aggregated in the main process. */
 export type RendererRuntimeMetrics = {
+  /** Latency from keydown to the data being sent over IPC, used to spot input lag. */
   inputKeydownToSend: RuntimeLatencyMetrics;
+  /** Rolling render-loop frame-timing statistics for this renderer. */
   frameTiming: RuntimeFrameTimingMetrics;
+  /** How often, in milliseconds, this snapshot is reported to the main process. */
   reportIntervalMs: number;
+  /** Timestamp at which this snapshot was last refreshed. */
   updatedAtMs: number;
 };
 
 /** Events emitted from the renderer and consumed by the privileged process. */
 export type MainEvents = {
+  /** Renderer window is being closed. */
   close: never;
+  /** A registered frontend command is being invoked in the main process. */
   command: CommandId;
-  data: {uid: SessionId | null; data: string; escaped?: boolean; inputSentAtMs?: number};
-  exit: {uid: SessionId};
-  'info renderer': {
+  /** Keystroke or pasted text to forward to the shell process. */
+  data: {
+    /** Target session, or `null` if no session is focused yet. */
+    uid: SessionId | null;
+    /** Raw bytes/text to write to the pty. */
+    data: string;
+    /** Whether `data` has already been shell-escaped by the renderer. */
+    escaped?: boolean;
+    /** Timestamp the keystroke was captured, used for input-latency metrics. */
+    inputSentAtMs?: number;
+  };
+  /** A session's shell process has terminated. */
+  exit: {
+    /** Session whose process exited. */
     uid: SessionId;
+  };
+  /** Renderer reporting its render backend and runtime health for diagnostics. */
+  'info renderer': {
+    /** Renderer session this report describes. */
+    uid: SessionId;
+    /** Rendering backend currently in use. */
     type: RendererType;
+    /** Reason the renderer fell back to this backend, if it did. */
     reason?: RendererFallbackReason;
+    /** Latest runtime performance snapshot from the renderer. */
     runtimeMetrics?: RendererRuntimeMetrics;
   };
+  /** Renderer has finished bootstrapping and is ready for session setup. */
   init: null;
+  /** Window maximize was requested. */
   maximize: never;
+  /** Window minimize was requested. */
   minimize: never;
+  /** A new terminal session is being created with the given options. */
   new: sessionExtraOptions;
+  /** Context-menu label selected by the user in the renderer. */
   'open context menu': string;
-  'open external': {url: string};
-  'open hamburger menu': {x: number; y: number};
+  /** A link should be opened in the user's default browser. */
+  'open external': {
+    /** URL to open externally. */
+    url: string;
+  };
+  /** Hamburger menu was requested at the given window-relative coordinates. */
+  'open hamburger menu': {
+    /** Horizontal position, in pixels, to anchor the menu at. */
+    x: number;
+    /** Vertical position, in pixels, to anchor the menu at. */
+    y: number;
+  };
+  /** User accepted an available update; install and relaunch. */
   'quit and install': never;
-  resize: {uid: SessionId; cols: number; rows: number};
+  /** Terminal dimensions changed and the pty should be resized to match. */
+  resize: {
+    /** Session whose pty should be resized. */
+    uid: SessionId;
+    /** New column count. */
+    cols: number;
+    /** New row count. */
+    rows: number;
+  };
+  /** Window unmaximize was requested. */
   unmaximize: never;
 };
 
 /** Events emitted from the privileged process and consumed by the renderer. */
 export type RendererEvents = {
+  /** Main process has finished initializing and the renderer may proceed. */
   ready: never;
-  'add notification': {text: string; url: string | null; dismissable: boolean};
-  'update available': {releaseNotes: string; releaseName: string; releaseUrl: string; canInstall: boolean};
+  /** A toast notification should be shown to the user. */
+  'add notification': {
+    /** Notification body text. */
+    text: string;
+    /** Optional link opened when the notification is clicked. */
+    url: string | null;
+    /** Whether the user can dismiss the notification without acting on it. */
+    dismissable: boolean;
+  };
+  /** An application update has been downloaded and can be installed. */
+  'update available': {
+    /** Changelog text for the new release. */
+    releaseNotes: string;
+    /** Human-readable name of the new release. */
+    releaseName: string;
+    /** Location of the release, shown as a link. */
+    releaseUrl: string;
+    /** Whether the update can be installed immediately from this state. */
+    canInstall: boolean;
+  };
+  /** An `ssh://` link was opened and should be handled by the SSH launcher. */
   'open ssh': ReturnType<typeof parseUrl>;
-  'open file': {path: string};
+  /** A local file should be opened (e.g. dropped onto the window). */
+  'open file': {
+    /** Filesystem path of the file to open. */
+    path: string;
+  };
+  /** Scroll to a specific line, or `'last'` to jump to the bottom. */
   'move jump req': number | 'last';
+  /** Reset terminal font size to its configured default. */
   'reset fontSize req': never;
+  /** Move focus to the pane on the left. */
   'move left req': never;
+  /** Move focus to the pane on the right. */
   'move right req': never;
+  /** Move focus to the previous pane in tab order. */
   'prev pane req': never;
+  /** Decrease terminal font size by one step. */
   'decrease fontSize req': never;
+  /** Increase terminal font size by one step. */
   'increase fontSize req': never;
+  /** Move focus to the next pane in tab order. */
   'next pane req': never;
+  /** Send a break signal to the active session's shell. */
   'session break req': never;
+  /** Close the active session. */
   'session quit req': never;
+  /** Close the in-terminal search bar. */
   'session search close': never;
+  /** Open the in-terminal search bar. */
   'session search': never;
+  /** Interrupt (Ctrl-C style) the active session. */
   'session stop req': never;
+  /** Toggle tmux mode for the active session. */
   'session tmux req': never;
+  /** Delete from the cursor to the beginning of the line. */
   'session del line beginning req': never;
+  /** Delete from the cursor to the end of the line. */
   'session del line end req': never;
+  /** Delete the word to the left of the cursor. */
   'session del word left req': never;
+  /** Delete the word to the right of the cursor. */
   'session del word right req': never;
+  /** Move the cursor to the beginning of the line. */
   'session move line beginning req': never;
+  /** Move the cursor to the end of the line. */
   'session move line end req': never;
+  /** Move the cursor one word to the left. */
   'session move word left req': never;
+  /** Move the cursor one word to the right. */
   'session move word right req': never;
+  /** Select all terminal buffer content. */
   'term selectAll': never;
+  /** Reload the renderer window. */
   reload: never;
+  /** Clear the active session's scrollback and screen. */
   'session clear req': never;
-  'split request horizontal': {activeUid?: SessionId; profile?: ProfileId};
-  'split request vertical': {activeUid?: SessionId; profile?: ProfileId};
-  'termgroup add req': {activeUid?: SessionId; profile?: ProfileId};
+  /** Split the active pane horizontally, optionally seeding a session/profile. */
+  'split request horizontal': {
+    /** Session the split is created relative to. */
+    activeUid?: SessionId;
+    /** Profile to launch the new pane with, overriding the default. */
+    profile?: ProfileId;
+  };
+  /** Split the active pane vertically, optionally seeding a session/profile. */
+  'split request vertical': {
+    /** Session the split is created relative to. */
+    activeUid?: SessionId;
+    /** Profile to launch the new pane with, overriding the default. */
+    profile?: ProfileId;
+  };
+  /** Open a new tab (terminal group), optionally seeding a session/profile. */
+  'termgroup add req': {
+    /** Session the new tab is created relative to. */
+    activeUid?: SessionId;
+    /** Profile to launch the new tab with, overriding the default. */
+    profile?: ProfileId;
+  };
+  /** Close the active tab (terminal group). */
   'termgroup close req': never;
+  /** A new session was created in the main process and should be mirrored in the UI. */
   'session add': Session;
+  /** Shell output to render into the terminal buffer. */
   'session data': string;
-  'session exit': {uid: SessionId};
-  'windowGeometry change': {isMaximized: boolean};
-  move: {bounds: {x: number; y: number}};
+  /** A session's shell process has terminated. */
+  'session exit': {
+    /** Session whose process exited. */
+    uid: SessionId;
+  };
+  /** The window's maximized state changed. */
+  'windowGeometry change': {
+    /** Whether the window is currently maximized. */
+    isMaximized: boolean;
+  };
+  /** The window was moved to a new position. */
+  move: {
+    /** New window bounds' origin. */
+    bounds: {
+      /** New horizontal window position, in pixels. */
+      x: number;
+      /** New vertical window position, in pixels. */
+      y: number;
+    };
+  };
+  /** The window entered full-screen mode. */
   'enter full screen': never;
+  /** The window left full-screen mode. */
   'leave full screen': never;
-  'session data send': {uid: SessionId | null; data: string; escaped?: boolean};
+  /** Keystroke or pasted text to write into a session, sent from the renderer. */
+  'session data send': {
+    /** Target session, or `null` if no session is focused yet. */
+    uid: SessionId | null;
+    /** Raw bytes/text to write to the pty. */
+    data: string;
+    /** Whether `data` has already been shell-escaped by the renderer. */
+    escaped?: boolean;
+  };
 };
 
 /** Get keys of T where the value is not never. */
@@ -157,11 +343,17 @@ export type FilterNever<T> = {[K in keyof T]: T[K] extends never ? never : K}[ke
 
 /** Minimal typed emitter contract shared by frontend and backend event bridges. */
 export interface TypedEmitter<Events> {
+  /** Registers a listener for an event, invoked on every occurrence. */
   on<E extends keyof Events>(event: E, listener: (args: Events[E]) => void): this;
+  /** Registers a listener for an event that fires at most once, then auto-removes. */
   once<E extends keyof Events>(event: E, listener: (args: Events[E]) => void): this;
+  /** Emits a payload-less event. */
   emit<E extends Exclude<keyof Events, FilterNever<Events>>>(event: E): boolean;
+  /** Emits an event with its associated payload. */
   emit<E extends FilterNever<Events>>(event: E, data: Events[E]): boolean;
+  /** Removes a single previously registered listener for an event. */
   removeListener<E extends keyof Events>(event: E, listener: (args: Events[E]) => void): this;
+  /** Removes all listeners for an event, or every listener if no event is given. */
   removeAllListeners<E extends keyof Events>(event?: E): this;
 }
 
@@ -169,21 +361,61 @@ type OptionalPromise<T> = T | Promise<T>;
 
 /** IPC command signatures available over Electron invoke handlers. */
 export type IpcCommands = {
-  'child_process.exec': (command: string, options: ExecOptions) => {stdout: string | Buffer; stderr: string | Buffer};
+  /** Runs a shell command via `child_process.exec` from the main process. */
+  'child_process.exec': (
+    command: string,
+    options: ExecOptions
+  ) => {
+    /** Captured standard output. */
+    stdout: string | Buffer;
+    /** Captured standard error. */
+    stderr: string | Buffer;
+  };
+  /** Runs a binary via `child_process.execFile` from the main process. */
   'child_process.execFile': (
     file: string,
     args: string[],
     options: ExecFileOptions
   ) => {
+    /** Captured standard output. */
     stdout: string | Buffer;
+    /** Captured standard error. */
     stderr: string | Buffer;
   };
-  getLoadedPluginVersions: () => {name: string; version: string}[];
-  getPaths: () => {plugins: string[]; localPlugins: string[]};
-  getBasePaths: () => {path: string; localPath: string};
-  getDeprecatedConfig: () => Record<string, {css: string[]}>;
+  /** Lists plugins currently loaded, with their installed versions. */
+  getLoadedPluginVersions: () => {
+    /** Plugin package name. */
+    name: string;
+    /** Installed plugin version. */
+    version: string;
+  }[];
+  /** Resolves the plugin and local-plugin directories in use. */
+  getPaths: () => {
+    /** Installed (npm) plugin directories. */
+    plugins: string[];
+    /** Local, non-npm plugin directories. */
+    localPlugins: string[];
+  };
+  /** Resolves the base config directory and its local-override counterpart. */
+  getBasePaths: () => {
+    /** Base configuration directory path. */
+    path: string;
+    /** Local (override) configuration directory path. */
+    localPath: string;
+  };
+  /** Returns config keys deprecated in favour of CSS, keyed by the deprecated option. */
+  getDeprecatedConfig: () => Record<
+    string,
+    {
+      /** CSS replacement rules for the deprecated option. */
+      css: string[];
+    }
+  >;
+  /** Resolves the fully merged configuration for a given profile. */
   getDecoratedConfig: (profile: string) => configOptions;
+  /** Resolves keymap bindings decorated with their resolved key combinations. */
   getDecoratedKeymaps: () => Record<string, string[]>;
+  /** Lists commands contributed by plugins loaded at runtime. */
   getRuntimePluginCommands: () => CommandDefinition[];
 };
 

--- a/shared/src/types/config.ts
+++ b/shared/src/types/config.ts
@@ -3,21 +3,37 @@ import type {FontWeight} from 'xterm';
 
 /** Terminal colour palette model used by profile configuration. */
 export type ColorMap = {
+  /** ANSI colour 0 (normal black). */
   black: string;
+  /** ANSI colour 4 (normal blue). */
   blue: string;
+  /** ANSI colour 6 (normal cyan). */
   cyan: string;
+  /** ANSI colour 2 (normal green). */
   green: string;
+  /** ANSI colour 8 (bright black / grey). */
   lightBlack: string;
+  /** ANSI colour 12 (bright blue). */
   lightBlue: string;
+  /** ANSI colour 14 (bright cyan). */
   lightCyan: string;
+  /** ANSI colour 10 (bright green). */
   lightGreen: string;
+  /** ANSI colour 13 (bright magenta). */
   lightMagenta: string;
+  /** ANSI colour 9 (bright red). */
   lightRed: string;
+  /** ANSI colour 15 (bright white). */
   lightWhite: string;
+  /** ANSI colour 11 (bright yellow). */
   lightYellow: string;
+  /** ANSI colour 5 (normal magenta). */
   magenta: string;
+  /** ANSI colour 1 (normal red). */
   red: string;
+  /** ANSI colour 7 (normal white). */
   white: string;
+  /** ANSI colour 3 (normal yellow). */
   yellow: string;
 };
 
@@ -224,6 +240,7 @@ export type configOptions = rootConfigOptions &
      * A list of profiles to use
      */
     profiles: {
+      /** Name used to select this profile when launching or splitting sessions. */
       name: string;
       /**
        * Specify all the options you want to override for each profile.
@@ -235,6 +252,7 @@ export type configOptions = rootConfigOptions &
 
 /** Raw user configuration payload as stored in config files. */
 export type rawConfig = {
+  /** Root configuration options as parsed from the config file, before profile merging. */
   config?: configOptions;
   /**
    * a list of plugins to fetch and install from npm
@@ -260,9 +278,13 @@ export type rawConfig = {
 
 /** Parsed configuration with normalized plugin and keymap arrays. */
 export type parsedConfig = {
+  /** Fully merged configuration, ready for use by the running application. */
   config: configOptions;
+  /** Normalized list of npm plugin specifiers to load. */
   plugins: string[];
+  /** Normalized list of local (non-npm) plugin directories to load. */
   localPlugins: string[];
+  /** Keymap bindings normalized to an array of key combinations per action. */
   keymaps: Record<string, string[]>;
 };
 

--- a/shared/src/types/context-keys.ts
+++ b/shared/src/types/context-keys.ts
@@ -15,36 +15,51 @@ export type WhenComparisonOperator = '==' | '!=' | '<' | '<=' | '>' | '>=';
 
 /** AST node representing an identifier lookup in the context map. */
 export interface WhenIdentifierNode {
+  /** Discriminant identifying this node as an identifier lookup. */
   kind: 'identifier';
+  /** Context key to resolve at evaluation time. */
   key: string;
 }
 
 /** AST node representing a literal value in an expression. */
 export interface WhenLiteralNode {
+  /** Discriminant identifying this node as a literal value. */
   kind: 'literal';
+  /** The literal's constant value. */
   value: ContextKeyValue;
 }
 
 /** AST node representing unary negation. */
 export interface WhenUnaryNode {
+  /** Discriminant identifying this node as a unary operation. */
   kind: 'unary';
+  /** Unary operator to apply. */
   operator: WhenUnaryOperator;
+  /** Sub-expression the operator is applied to. */
   operand: WhenExpressionNode;
 }
 
 /** AST node representing a logical conjunction/disjunction. */
 export interface WhenLogicalNode {
+  /** Discriminant identifying this node as a logical operation. */
   kind: 'logical';
+  /** Logical operator combining the two operands. */
   operator: WhenLogicalOperator;
+  /** Left-hand sub-expression. */
   left: WhenExpressionNode;
+  /** Right-hand sub-expression. */
   right: WhenExpressionNode;
 }
 
 /** AST node representing value comparison. */
 export interface WhenComparisonNode {
+  /** Discriminant identifying this node as a comparison. */
   kind: 'comparison';
+  /** Comparison operator to apply. */
   operator: WhenComparisonOperator;
+  /** Left-hand sub-expression. */
   left: WhenExpressionNode;
+  /** Right-hand sub-expression. */
   right: WhenExpressionNode;
 }
 
@@ -58,28 +73,44 @@ export type WhenExpressionNode =
 
 /** Parse error payload for invalid `when` expressions. */
 export interface WhenExpressionParseError {
+  /** Human-readable description of why parsing failed. */
   message: string;
+  /** Original `when` expression text that failed to parse. */
   source: string;
+  /** Character offset within `source` where the parser gave up. */
   index: number;
 }
 
 /** Immutable compiled expression payload with source and AST. */
 export interface CompiledWhenExpression {
+  /** Original `when` expression text the AST was compiled from. */
   source: string;
+  /** Parsed AST ready for repeated evaluation without re-parsing. */
   ast: WhenExpressionNode;
 }
 
 /** Runtime API for managing context keys and evaluating `when` expressions. */
 export interface ContextKeyService {
+  /** Sets a context key's value, updating any `when` expressions that depend on it. */
   set(key: string, value: ContextKeyValue): void;
+  /** Reads a context key's current value. */
   get(key: string): ContextKeyValue | undefined;
+  /** Reports whether a context key is currently set. */
   has(key: string): boolean;
+  /** Removes a context key; returns whether it was present. */
   delete(key: string): boolean;
+  /** Removes all context keys. */
   clear(): void;
+  /** Captures an immutable snapshot of all current context key values. */
   snapshot(): ContextKeyMap;
+  /** Parses a `when` expression into an AST without evaluating it. */
   parse(expression: string): WhenExpressionNode;
+  /** Parses a `when` expression and packages it with its source for reuse. */
   compile(expression: string): CompiledWhenExpression;
+  /** Parses and evaluates a `when` expression against the current context. */
   evaluate(expression: string): boolean;
+  /** Evaluates a previously parsed AST against the current context. */
   evaluateAst(ast: WhenExpressionNode): boolean;
+  /** Evaluates a previously compiled expression against the current context. */
   evaluateCompiled(compiled: CompiledWhenExpression): boolean;
 }

--- a/shared/tsconfig.typedoc.json
+++ b/shared/tsconfig.typedoc.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "incremental": true,
+    "noEmit": false,
+    "emitDeclarationOnly": false
+  }
+}

--- a/typedoc.app.json
+++ b/typedoc.app.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./typedoc.base.json",
+  "tsconfig": "tsconfig.typecheck.json",
+  "entryPoints": ["app", "cli", "lib"],
+  "entryPointStrategy": "expand"
+}

--- a/typedoc.backend.json
+++ b/typedoc.backend.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./typedoc.base.json",
+  "tsconfig": "backend/tsconfig.typedoc.json",
+  "entryPoints": ["backend/src"],
+  "entryPointStrategy": "expand"
+}

--- a/typedoc.base.json
+++ b/typedoc.base.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "emit": "none",
+  "commentStyle": "jsdoc",
+  "excludeExternals": true,
+  "excludeInternal": true,
+  "excludePrivate": true,
+  "excludeProtected": true,
+  "exclude": ["**/*.d.ts", "**/node_modules/**", "**/dist/**", "**/test/**", "**/tests/**"],
+  "validation": {
+    "notDocumented": true,
+    "notExported": false,
+    "invalidLink": false,
+    "invalidPath": false,
+    "rewrittenLink": false,
+    "unusedMergeModuleWith": false
+  },
+  "requiredToBeDocumented": [
+    "Enum",
+    "EnumMember",
+    "Variable",
+    "Function",
+    "Class",
+    "Interface",
+    "Property",
+    "Method",
+    "Accessor",
+    "TypeAlias"
+  ],
+  "treatValidationWarningsAsErrors": true
+}

--- a/typedoc.frontend.json
+++ b/typedoc.frontend.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./typedoc.base.json",
+  "tsconfig": "frontend/tsconfig.typedoc.json",
+  "entryPoints": ["frontend/src"],
+  "entryPointStrategy": "expand"
+}

--- a/typedoc.shared.json
+++ b/typedoc.shared.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./typedoc.base.json",
+  "tsconfig": "shared/tsconfig.typedoc.json",
+  "entryPoints": ["shared/src"],
+  "entryPointStrategy": "expand"
+}


### PR DESCRIPTION
## Summary

This branch adds a zero-tolerance TypeDoc documentation gate to
`make all`, with one TypeDoc configuration per TypeScript project —
`shared`, `frontend`, `backend`, and the application surface (`app`,
`cli`, and `lib` through `tsconfig.typecheck.json`) — rather than
forcing projects with distinct compiler configurations through one
giant invocation. Each configuration extends a common
`typedoc.base.json` with `emit: "none"` and validation warnings treated
as errors: every exported declaration in the selected surfaces must
carry a JSDoc comment. The gate reports the qualified name of each
undocumented declaration, writes no documentation artefacts, and fails
on a single omission. The Node.js CI workflow runs `make docs-check`
between its lint and test gates.

The first commit documents roughly 1,400 declarations and properties
across `shared/src`, `app/`, `lib/`, and `cli/` (the `frontend` and
`backend` projects were already fully documented); the second wires the
gate.

## Review walkthrough

- Start with [typedoc.base.json](https://github.com/leynos/velocetty/blob/a0d32477/typedoc.base.json)
  and the four project configurations
  ([typedoc.shared.json](https://github.com/leynos/velocetty/blob/a0d32477/typedoc.shared.json),
  [typedoc.frontend.json](https://github.com/leynos/velocetty/blob/a0d32477/typedoc.frontend.json),
  [typedoc.backend.json](https://github.com/leynos/velocetty/blob/a0d32477/typedoc.backend.json),
  [typedoc.app.json](https://github.com/leynos/velocetty/blob/a0d32477/typedoc.app.json)).
  The per-project `tsconfig.typedoc.json` shims add `incremental` so
  plain tsc (which TypeDoc drives) accepts the projects'
  `tsBuildInfoFile` settings that `tsgo` tolerates.
- Then the wiring: [package.json](https://github.com/leynos/velocetty/blob/a0d32477/package.json)
  (`docs:check` chaining the four configurations), the
  [Makefile](https://github.com/leynos/velocetty/blob/a0d32477/Makefile),
  and [.github/workflows/nodejs.yml](https://github.com/leynos/velocetty/blob/a0d32477/.github/workflows/nodejs.yml).
- The documentation pass is best sampled via
  [shared/src/types/common.ts](https://github.com/leynos/velocetty/blob/a0d32477/shared/src/types/common.ts)
  (the cross-process event and IPC vocabulary),
  [lib/components/term.tsx](https://github.com/leynos/velocetty/blob/a0d32477/lib/components/term.tsx)
  (the terminal component), and
  [lib/transport/ipc-schemas.ts](https://github.com/leynos/velocetty/blob/a0d32477/lib/transport/ipc-schemas.ts) —
  the IPC response schema registry keeps field-level docs but is tagged
  `@internal` as a machine seam, since zod's enum-member reflections
  cannot carry comments.

## Validation

- `make all` (check-fmt, typecheck, `docs-check`, lint, test,
  spelling): exit 0. The pre-commit hook's unit-test run also passes
  (428 tests, 0 failures).
- Mutation check: deleting the JSDoc line from the exported `CommandId`
  alias makes `bun run docs:check` exit 4 naming the symbol; restoring
  it returns the gate to green.
- A clean `docs:check` run emits no files.

## Notes

- Part of the estate-wide TypeDoc gate rollout (same shape as
  leynos/df12-build#62, leynos/dakar#5, leynos/digitalpuddle#47,
  leynos/simulacat-core#58, leynos/vibe-coder#110, leynos/corbusier#156,
  and leynos/wildside#436).
